### PR TITLE
Replacing _.each with async.each

### DIFF
--- a/controllers/data.js
+++ b/controllers/data.js
@@ -1,7 +1,7 @@
 var _ = require('underscore'),
 	rest = require('restler'),
 	parseString = require('xml2js').parseString,
-	HighChartsData = require('../models/HighChartsData'),
+	HighCharts = require('./highCharts'),
 	UserTableModel = require('../models/UserTable'),
 	RedditPostModel = require('../models/RedditPost');
 
@@ -11,19 +11,40 @@ module.exports = function(app, dataStore, MemoryStore) {
 		PokemonHash = MemoryStore.store.PokemonHash,
 		CountryHash = MemoryStore.store.CountryHash;
 
-	function setupHighChartsData(req, resp, next){
+	function setupHighChartsData(req, res, next){
 
 		req.highChartsData = MemoryStore.store.highChartsData;
 		req.result= MemoryStore.store.highChartsResults;
+		req.data = {};
 		next();
 	}
 
-	function setupUserTableData(req, resp, next) {
-		// TODO
+	function setupUserTableData(req, res, next) {
+
+		dataStore.lrange('userTable' , 0, -1, function(error, result){
+			req.userTable = new UserTableModel(result);
+			next();
+		});
+	}
+
+	function findRedditUserName (req, res, next) {
+
+		var userId = req.params.userId;
+		dataStore.lrange('redditUser' , 0, -1, function(error, result){
+
+			for(var i = 0, max = result.length;i < max;i++) {
+				var parsedUser = JSON.parse(result[i]);
+				if(parsedUser.userId == userId) {
+					req.data.redditUserName = parsedUser.redditUserName;
+					return next();
+				}
+			}
+
+			next();
+		});
 	}
 
 	function OverviewPage(req, resp){
-		var highChartsData = req.highChartsData;
 		resp.render('data/index', {
 			title: 'Wonder Trade Analytics',
 			pageState: '',
@@ -31,210 +52,140 @@ module.exports = function(app, dataStore, MemoryStore) {
 			CountryHash: CountryHash,
 			result: req.result,
 			user: req.user,
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon()),
-			genderChart: JSON.stringify(highChartsData.getCountsByGender()),
-			countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries())
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries)
 		});
 	}
-
 	function PokemonPage(req, resp){
-
-		var highChartsData = req.highChartsData,
-			topPokemon = highChartsData.getTopPokemon(5),
-			topPokemonIds = _.map(topPokemon, function(pkmn){return parseInt(pkmn[0], 10);}),
-			trendingChart = JSON.stringify(highChartsData.getCachedTrendByPokemonIds(topPokemonIds));
-
 		resp.render('data/pokemon', {
 			title: 'Pokemon Overview',
 			pageState: '',
 			result: req.result,
 			PokemonHash: PokemonHash,
-			trendingPokemonChart: trendingChart,
-			levelBarChart: JSON.stringify(highChartsData.getCountsByLevels()),
+			trendingPokemonChart: JSON.stringify(req.data.cachedTrendByPokemonIds),
+			levelBarChart: JSON.stringify(req.data.countsByLevels),
 			pokemonList: PokemonList,
 			user: req.user,
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon()),
-			quickstats: highChartsData.getQuickStats()
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			quickstats: req.data.quickstats
 		});
 	}
-
-	function PokemonByIdPage(req, resp){
-		var pokemonId = req.params.pokemonId,
-			highChartsData = req.highChartsData,
-			highChartsDataByPokemonId = highChartsData.getResultsByPokemonId(pokemonId),
-			nicknames = highChartsData.getNicknamesByResultSet(highChartsDataByPokemonId),
+	function PokemonByIdPage(req, res) {
+		var pokemonId = parseInt(req.params.pokemonId, 10),
 			pokemonName = PokemonHash[pokemonId];
 
-		resp.render('data/pokemonById', {
+		if (!(pokemonId > 0 && pokemonId < 719)) {
+			return res.redirect('404');
+		}
+
+		res.render('data/pokemonById', {
 			title: pokemonName+' Analytics',
 			pageState: '',
 			result: req.result,
 			pokemonName: pokemonName,
 			pokemonId: pokemonId,
 			user: req.user,
-			nicknames: nicknames,
-			trendingPokemonChart: JSON.stringify(highChartsData.getCachedTrendByPokemonId(pokemonId)),
-			levelBarChart: JSON.stringify(highChartsData.getCountsByLevels(highChartsDataByPokemonId)),
-			genderChart: JSON.stringify(highChartsData.getCountsByGender(highChartsDataByPokemonId)),
-			countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataByPokemonId)),
-			quickstats: highChartsData.getQuickStats(highChartsDataByPokemonId)
+			nicknames: req.data.nicknames,
+			trendingPokemonChart: JSON.stringify(req.data.cachedTrendByPokemonId),
+			levelBarChart: JSON.stringify(req.data.countsByLevels),
+			genderChart: JSON.stringify(req.data.countsByGender),
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries),
+			quickstats: req.data.quickstats
 		});
 	}
-
 	function RegionsPage(req, resp){
-		var highChartsData = req.highChartsData,
-			regionsTable = highChartsData.getRegionsTable();
-
-		regionsTable.reverse();
-
 		resp.render('data/regions', {
 			title: 'Wonder Trade Region Analytics',
 			pageState: '',
-			regionsTable: regionsTable,
 			user: req.user,
 			totalCount: req.result.length,
-			countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries())
+			countryList: req.data.sortedCountsByCountries,
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries)
 		});
 	}
-
 	function RegionByIdPage(req, resp){
 		var regionId = req.params.regionCode,
-			highChartsData = req.highChartsData,
-			highChartsDataByRegionId = highChartsData.getResultsByRegionId(regionId),
-			timeTrends = highChartsData.getDataCountsSplitByTime(highChartsDataByRegionId),
 			regionName = CountryHash[regionId];
 
 		resp.render('data/regionById', {
 			title: regionName+' Analytics',
 			pageState: '',
 			regionName: regionName,
-			genderChart: JSON.stringify(highChartsData.getCountsByGender(highChartsDataByRegionId)),
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataByRegionId)),
-			subregionChart: JSON.stringify(highChartsData.getCountsBySubRegions(highChartsDataByRegionId)),
-			timeTrends: JSON.stringify(timeTrends),
-			quickstats: highChartsData.getQuickStats(highChartsDataByRegionId),
+			genderChart: JSON.stringify(req.data.countsByGender),
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			subregionChart: JSON.stringify(req.data.countsBySubRegions),
+			timeTrends: JSON.stringify(req.data.dataCountsSplitByTime),
+			quickstats: req.data.quickstats,
 			user: req.user
 		});
 	}
-
-	function NicknamesPage(req, resp){
-
-		dataStore.lrange('userTable' , 0, -1, function(error, result){
-			var userTable = new UserTableModel(result),
-				highChartsData = req.highChartsData,
-				highChartsDataWithNicknames = highChartsData.getNicknamesTable();
-
-			resp.render('data/nicknames', {
-				title: 'Nickname Analytics',
-				pageState: '',
-				wondertradeTable: highChartsDataWithNicknames,
-				pokemonHash: PokemonHash,
-				userTable: userTable,
-				user: req.user
-			});
-		});
-	}
-
 	function HiddenAbilitiesPage(req, resp){
-		var highChartsData = req.highChartsData,
-			highChartsDataWithHiddenAbilities = highChartsData.getResultsWithHiddenAbilities(),
-			pokemonTable = highChartsData.getPokemonTable(highChartsDataWithHiddenAbilities);
-
-
-		pokemonTable.reverse();
-
 		resp.render('data/hiddenAbilities', {
 			title: 'Pokemon with Hidden Abilities',
 			pageState: '',
 			result: req.result,
 			PokemonHash: PokemonHash,
-			levelBarChart: JSON.stringify(highChartsData.getCountsByLevels(highChartsDataWithHiddenAbilities)),
-			countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataWithHiddenAbilities)),
+			levelBarChart: JSON.stringify(req.data.countsByLevels),
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries),
 			pokemonList: PokemonList,
 			user: req.user,
-			pokemonTable: pokemonTable,
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataWithHiddenAbilities)),
-			quickstats: highChartsData.getQuickStats(highChartsDataWithHiddenAbilities)
+			pokemonTable: req.data.sortedCountsByPokemon,
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			quickstats: req.data.quickstats
 		});
 	}
 	function PerfectIVPage(req, resp){
-		var highChartsData = req.highChartsData,
-			highChartsDataWithPerfectIV = highChartsData.getResultsWithPerfectIV(),
-			pokemonTable = highChartsData.getPokemonTable(highChartsDataWithPerfectIV);
-
-		pokemonTable.reverse();
-
 		resp.render('data/perfectIV', {
-			title: 'Pokemon with Hidden Abilities',
+			title: 'Pokemon with Perfect IVs',
 			pageState: '',
 			result: req.result,
 			PokemonHash: PokemonHash,
-			levelBarChart: JSON.stringify(highChartsData.getCountsByLevels(highChartsDataWithPerfectIV)),
-			countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataWithPerfectIV)),
+			levelBarChart: JSON.stringify(req.data.countsByLevels),
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries),
 			pokemonList: PokemonList,
 			user: req.user,
-			pokemonTable: pokemonTable,
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataWithPerfectIV)),
-			quickstats: highChartsData.getQuickStats(highChartsDataWithPerfectIV)
+			pokemonTable: req.data.sortedCountsByPokemon,
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			quickstats: req.data.quickstats
 		});
 	}
-
 	function ShinyPage(req, resp){
-		var highChartsData = req.highChartsData,
-			highChartsDataWithPerfectIV = highChartsData.getResultsWithShinyPokemon(),
-			pokemonTable = highChartsData.getPokemonTable(highChartsDataWithPerfectIV);
-
-		pokemonTable.reverse();
-
 		resp.render('data/shiny', {
 			title: 'Shiny Pokemon',
 			pageState: '',
 			result: req.result,
 			PokemonHash: PokemonHash,
-			levelBarChart: JSON.stringify(highChartsData.getCountsByLevels(highChartsDataWithPerfectIV)),
-			countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataWithPerfectIV)),
+			levelBarChart: JSON.stringify(req.data.countsByLevels),
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries),
 			pokemonList: PokemonList,
 			user: req.user,
-			pokemonTable: pokemonTable,
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataWithPerfectIV)),
-			quickstats: highChartsData.getQuickStats(highChartsDataWithPerfectIV)
+			pokemonTable: req.data.sortedCountsByPokemon,
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			quickstats: req.data.quickstats
 		});
 	}
 
 	function GenderPage(req, resp){
-		var highChartsData = req.highChartsData,
-			maleResults = highChartsData.getResultsByGender('male'),
-			femaleResults = highChartsData.getResultsByGender('female'),
-			maleSortedSet = highChartsData.getSortedCountsByPokemon(maleResults),
-			femaleSortedSet = highChartsData.getSortedCountsByPokemon(femaleResults);
-
-		maleSortedSet = maleSortedSet.reverse();
-		maleSortedSet =  _.first(maleSortedSet,10);
-
-		femaleSortedSet = femaleSortedSet.reverse();
-		femaleSortedSet =  _.first(femaleSortedSet,10);
-
+		var genderData = req.data.genderData;
 
 		resp.render('data/gender', {
 			title: 'Wonder Trade Analytics',
 			pageState: '',
 			result: req.result,
 			PokemonHash: PokemonHash,
-			maleQuickstats: highChartsData.getQuickStats(maleResults),
-			femaleQuickstats: highChartsData.getQuickStats(femaleResults),
+			maleQuickstats: genderData.maleQuickstats,
+			femaleQuickstats: genderData.femaleQuickstats,
 			user: req.user,
-			malePokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(maleResults)),
-			maleCountryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(maleResults)),
-			maleTopTenPokemon: maleSortedSet,
-			femalePokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(femaleResults)),
-			femaleCountryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(femaleResults)),
-			femaleTopTenPokemon: femaleSortedSet
+			malePokemonChart: JSON.stringify(genderData.malePokemonChart),
+			maleCountryChart: JSON.stringify(genderData.maleCountryChart),
+			maleTopTenPokemon: genderData.maleTopTenPokemon,
+			femalePokemonChart: JSON.stringify(genderData.femalePokemonChart),
+			femaleCountryChart: JSON.stringify(genderData.femaleCountryChart),
+			femaleTopTenPokemon: genderData.femaleTopTenPokemon
 		});
 	}
 
 	function LevelsPage(req, resp){
-		var highChartsData = req.highChartsData;
-
 		resp.render('data/levels', {
 			title: 'Level Analytics',
 			pageState: '',
@@ -242,255 +193,173 @@ module.exports = function(app, dataStore, MemoryStore) {
 			PokemonHash: PokemonHash,
 			CountryHash: CountryHash,
 			user: req.user,
-			levelBarChart: JSON.stringify(highChartsData.getCountsByLevels()),
+			levelBarChart: JSON.stringify(req.data.countsByLevels)
 		});
 	}
-
 	function LevelPage(req, resp){
 		var pokemonLevel = req.params.pokemonLevel,
-			highChartsData = req.highChartsData,
-			highChartsDataByLevel = highChartsData.getResultsByPokemonLevel(pokemonLevel),
 			integerPokemonLevel = parseInt(pokemonLevel, 10);
 
 		resp.render('data/byLevel', {
-			title: 'Level '+integerPokemonLevel+' Analytics',
+			title: 'Level '+integerPokemonLevel+' Pokemon Analytics',
 			pageState: '',
 			result: req.result,
 			pokemonLevel: integerPokemonLevel,
 			user: req.user,
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataByLevel)),
-			genderChart: JSON.stringify(highChartsData.getCountsByGender(highChartsDataByLevel)),
-			countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataByLevel)),
-			quickstats: highChartsData.getQuickStats(highChartsDataByLevel)
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			genderChart: JSON.stringify(req.data.countsByGender),
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries),
+			quickstats: req.data.quickstats
 		});
 	}
-
 	function DatesPage(req, resp){
-		var highChartsData = req.highChartsData,
-			statTrendsByDate = highChartsData.getCachedQuickStatsTrendsByDates();
-
 		resp.render('data/dates', {
-			title: 'Wonder Trade Analytics',
+			title: 'Wonder Trade Trends (By Date)',
 			pageState: '',
 			user: req.user,
 			stateMessage: '',
-			quickStatTrends: JSON.stringify(statTrendsByDate)
+			quickStatTrends: JSON.stringify(req.data.cachedQuickStatsTrendsByDates)
 		});
 	}
-
 	function DatePage(req, resp){
-		dataStore.lrange('userTable' , 0, -1, function(error, result){
-			var userTable = new UserTableModel(result),
-				submissionDate = req.params.submissionDate,
-				highChartsData = req.highChartsData,
-				highChartsDataBySubmissionDate = highChartsData.getResultsBySubmissionDate(submissionDate),
-				pokemonTable = highChartsData.getPokemonTable(highChartsDataBySubmissionDate),
-				userChart = highChartsData.getCountsByUserIdAndUserTableFormatted(highChartsDataBySubmissionDate, userTable);
 
-			pokemonTable.reverse();
+		var submissionDate = req.params.submissionDate;
 
-			resp.render('data/datesByDay', {
-				title: ' Analytics for '+submissionDate,
-				pageState: '',
-				user: req.user,
-				submissionDate: submissionDate,
-				userChart: JSON.stringify(userChart),
-				wondertradeTends: JSON.stringify(highChartsData.getTrendsByDate(highChartsDataBySubmissionDate)),
-				pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataBySubmissionDate)),
-				genderChart: JSON.stringify(highChartsData.getCountsByGender(highChartsDataBySubmissionDate)),
-				pokemonTable: pokemonTable,
-				quickstats: highChartsData.getQuickStats(highChartsDataBySubmissionDate),
-				countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataBySubmissionDate))
-			});
-
+		resp.render('data/datesByDay', {
+			title: ' Analytics for '+submissionDate,
+			pageState: '',
+			user: req.user,
+			submissionDate: submissionDate,
+			userChart: JSON.stringify(req.data.countsByUserIdAndUserTableFormatted),
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			pokemonTable: req.data.sortedCountsByPokemon,
+			quickstats: req.data.quickstats,
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries)
 		});
 	}
-
-
 	function DateRangePage (req, resp) {
-		dataStore.lrange('userTable' , 0, -1, function(error, result){
-			var userTable = new UserTableModel(result),
-				startDate = req.params.startDate,
-				endDate = req.params.endDate || 'Now',
-				highChartsData = req.highChartsData,
-				highChartsDataBySubmissionDate = highChartsData.getResultsByDateRange(startDate, endDate),
-				pokemonTable = highChartsData.getPokemonTable(highChartsDataBySubmissionDate),
-				userChart = highChartsData.getCountsByUserIdAndUserTableFormatted(highChartsDataBySubmissionDate, userTable);
 
-			pokemonTable.reverse();
+		var startDate = req.params.startDate,
+			endDate = req.params.endDate || 'Now';
 
-			resp.render('data/dateRange', {
-				title: ' Analytics for ' + startDate + ' - ' + endDate,
-				pageState: '',
-				user: req.user,
-				startDate: startDate,
-				endDate: endDate,
-				userChart: JSON.stringify(userChart),
-				wondertradeTends: JSON.stringify(highChartsData.getTrendsByDate(highChartsDataBySubmissionDate)),
-				pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataBySubmissionDate)),
-				genderChart: JSON.stringify(highChartsData.getCountsByGender(highChartsDataBySubmissionDate)),
-				pokemonTable: pokemonTable,
-				quickstats: highChartsData.getQuickStats(highChartsDataBySubmissionDate),
-				countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataBySubmissionDate))
-			});
-
+		resp.render('data/dateRange', {
+			title: ' Analytics for ' + startDate + ' - ' + endDate,
+			pageState: '',
+			user: req.user,
+			startDate: startDate,
+			endDate: endDate,
+			userChart: JSON.stringify(req.data.countsByUserIdAndUserTableFormatted),
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			genderChart: JSON.stringify(req.data.countsByGender),
+			pokemonTable: req.data.sortedCountsByPokemon,
+			quickstats: req.data.quickstats,
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries)
 		});
 	}
-
-
 	function TimePage(req, resp) {
-		var highChartsData = req.highChartsData,
-			dataSplitByTime = highChartsData.getDataSplitByTime(),
-			statTrendsByTime = highChartsData.getQuickStatsTrendsByTime(dataSplitByTime);
-
 		resp.render('data/times', {
 			title: 'WonderTrade Data by Submission Time',
 			pageState: '',
 			user: req.user,
 			stateMessage: '',
-			quickStatTrends: JSON.stringify(statTrendsByTime)
+			quickStatTrends: JSON.stringify(req.data.quickStatsTrendsByTime)
 		});
 	}
-
 	function LikesPage(req, resp){
-		var highChartsData = req.highChartsData,
-			pokemonLikenessList = highChartsData.getCommunityLikes();
-
 		resp.render('data/likes', {
 			title: 'Wonder Trade Sentiment',
 			pageState: '',
 			user: req.user,
-			pokemonLikenessList: pokemonLikenessList
+			pokemonLikenessList: req.data.communityLikes
 		});
 	}
-
 	function OTPage(req, resp){
-		var highChartsData = req.highChartsData,
-			originalTrainers = highChartsData.getCachedOriginalTrainers();
-
 		resp.render('data/originalTrainers', {
 			title: 'Original Trainer\'s recorded',
 			pageState: '',
 			user: req.user,
-			originalTrainers: originalTrainers
+			originalTrainers: req.data.cachedOriginalTrainers
 		});
 	}
-
 	function OTPageById(req, resp){
-		var highChartsData = req.highChartsData,
-			trainerId = req.params.trainerId,
-			originalTrainers = highChartsData.getOriginalTrainersById(trainerId);
 
+		var trainerId = req.params.trainerId;
 		resp.render('data/originalTrainersById', {
 			title: 'Wonder Trades By '+trainerId,
 			pageState: '',
 			user: req.user,
-			originalTrainers: originalTrainers
+			originalTrainers: req.data.originalTrainersById
 		});
 	}
-
 	function UserIdPage(req, resp){
 
-		var userId = req.params.userId;
-
-		dataStore.lrange('redditUser' , 0, -1, function(error, result){
-			var redditUserName = '';
-			for(var user in result) {
-				var parsedUser = JSON.parse(result[user]);
-				if(parsedUser.userId == userId) {
-					redditUserName = parsedUser.redditUserName;
-				}
-			}
-
-			dataStore.lrange('userTable' , 0, -1, function(error, result){
-				var userTable = new UserTableModel(result);
-
-				var highChartsData = req.highChartsData,
-					highChartsDataByUserId = highChartsData.getResultsByUserId(userId),
-					pokemonTable = highChartsData.getPokemonTable(highChartsDataByUserId),
-					trendsByDate = highChartsData.getTrendsByDate(highChartsDataByUserId),
-					submissionDates = highChartsData.getSubmissionDates(highChartsDataByUserId),
-					userName = userTable[userId];
-
-				pokemonTable.reverse();
-
-				var mav = {
-					title: ' Analytics for '+userName,
-					pageState: '',
-					user: req.user,
-					username: userName,
-					userId: userId,
-					wondertradeTends: JSON.stringify(trendsByDate),
-					submissionDates: submissionDates,
-					pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataByUserId)),
-					genderChart: JSON.stringify(highChartsData.getCountsByGender(highChartsDataByUserId)),
-					levelBarChart: JSON.stringify(highChartsData.getCountsByLevels(highChartsDataByUserId)),
-					pokemonTable: pokemonTable,
-					quickstats: highChartsData.getQuickStats(highChartsDataByUserId),
-					countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataByUserId)),
-					redditResults: false
-				};
-
-				if (redditUserName && redditUserName !== '') {
-					var redditPostsRequest = rest.get('http://www.reddit.com/r/WonderTrade/search.rss?q=subreddit%3Awondertrade+author%3A'+redditUserName);
-					redditPostsRequest.once('complete', function(data) {
-						parseString(data, function (err, result) {
-
-							if(result && result.rss && result.rss.channel && result.rss.channel[0]) {
-								var redditPosts = [];
-								for(var item in result.rss.channel[0].item) {
-									var redditItem = result.rss.channel[0].item[item];
-									if(redditItem) {
-										var redditPost = new RedditPostModel(redditItem);
-										redditPosts.push(redditPost);
-									}
-								}
-								mav.redditResults = redditPosts;
-							}
-							resp.render('data/user', mav);
-
-							redditPostsRequest.removeAllListeners('error');
-						});
-					});
-				} else {
-					resp.render('data/user', mav);
-				}
-
-			});
-		});
-	}
-
-	function UserIdDatePage(req, resp){
-
-		dataStore.lrange('userTable' , 0, -1, function(error, result){
-			var userTable = new UserTableModel(result),
-				userId = req.params.userId,
-				submissionDate = req.params.submissionDate,
-				highChartsData = req.highChartsData,
-				highChartsDataByUserId = highChartsData.getResultsByUserIdAndSubmissionDate(userId, submissionDate),
-				pokemonTable = highChartsData.getPokemonTable(highChartsDataByUserId),
-				userName = userTable[userId];
-
-			pokemonTable.reverse();
-
-			resp.render('data/userDate', {
+		var userId = req.params.userId,
+			userName = req.userTable[userId],
+			redditUserName = req.data.redditUserName,
+			mav = {
 				title: ' Analytics for '+userName,
 				pageState: '',
 				user: req.user,
 				username: userName,
-				submissionDate: submissionDate,
-				wondertradeTends: JSON.stringify(highChartsData.getTrendsByDate(highChartsDataByUserId)),
-				pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(highChartsDataByUserId)),
-				genderChart: JSON.stringify(highChartsData.getCountsByGender(highChartsDataByUserId)),
-				levelBarChart: JSON.stringify(highChartsData.getCountsByLevels(highChartsDataByUserId)),
-				pokemonTable: pokemonTable,
-				quickstats: highChartsData.getQuickStats(highChartsDataByUserId),
-				countryChart: JSON.stringify(highChartsData.getSortedCountsByCountries(highChartsDataByUserId))
-			});
+				userId: userId,
+				submissionDates: req.data.submissionDates,
+				pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+				genderChart: JSON.stringify(req.data.countsByGender),
+				wondertradeTrends: JSON.stringify(req.data.trendsByDate),
+				levelBarChart: JSON.stringify(req.data.countsByLevels),
+				pokemonTable: req.data.sortedCountsByPokemon,
+				quickstats: req.data.quickstats,
+				countryChart: JSON.stringify(req.data.sortedCountsByCountries),
+				redditResults: false
+			};
 
+		// TODO: decrease page loads by moving this to clientside
+		if (redditUserName && redditUserName !== '') {
+			var redditPostsRequest = rest.get('http://www.reddit.com/r/WonderTrade/search.rss?q=subreddit%3Awondertrade+author%3A'+redditUserName);
+			redditPostsRequest.once('complete', function(data) {
+				parseString(data, function (err, result) {
+
+					if(result && result.rss && result.rss.channel && result.rss.channel[0]) {
+						var redditPosts = [];
+						for(var item in result.rss.channel[0].item) {
+							var redditItem = result.rss.channel[0].item[item];
+							if(redditItem) {
+								var redditPost = new RedditPostModel(redditItem);
+								redditPosts.push(redditPost);
+							}
+						}
+						mav.redditResults = redditPosts;
+					}
+					resp.render('data/user', mav);
+
+					redditPostsRequest.removeAllListeners('error');
+				});
+			});
+		} else {
+			resp.render('data/user', mav);
+		}
+	}
+	function UserIdDatePage(req, res) {
+
+		var userTable = req.userTable,
+			userId = req.params.userId,
+			userName = userTable[userId],
+			submissionDate = req.params.submissionDate;
+
+		res.render('data/userDate', {
+			title: ' Analytics for '+userName,
+			pageState: '',
+			user: req.user,
+			username: userName,
+			submissionDate: submissionDate,
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			genderChart: JSON.stringify(req.data.countsByGender),
+			levelBarChart: JSON.stringify(req.data.countsByLevels),
+			pokemonTable: req.data.sortedCountsByPokemon,
+			quickstats: req.data.quickstats,
+			countryChart: JSON.stringify(req.data.sortedCountsByCountries)
 		});
 	}
-
 	function GroupsPage(req, resp) {
 		resp.render('data/groups', {
 			title: 'Pokemon Data Sorted by Custom Groups',
@@ -498,133 +367,103 @@ module.exports = function(app, dataStore, MemoryStore) {
 			user: req.user
 		});
 	}
-
-	function GroupsPage_Eevee(req, resp, next) {
-		req.groupName = "Eeveelutions";
-		req.pokemonGroupArray = [134, 135, 136, 196, 197, 470, 471, 700];
-		next();
-	}
-	function GroupsPage_Starters(req, resp, next) {
-		req.groupName = "Starters";
-		req.pokemonGroupArray = [1, 4, 7, 152, 155, 158, 252, 255, 258, 387, 390, 393, 495, 498, 501, 650, 653, 656];
-		next();
-	}
-	function GroupsPage_TradeEvos(req, resp, next) {
-		req.groupName = "Trade Evolutions";
-		req.pokemonGroupArray = [64, 67, 75, 93, 525, 533, 708, 711];
-		next();
-	}
-
-	function GroupsPage_TrioLegendary(req, resp, next) {
-		req.groupName = "Trio Legendarys";
-		req.pokemonGroupArray = [144, 145, 146, 243, 244, 245, 377, 378, 379, 480, 481, 482, 638, 639, 640];
-		next();
-	}
-
-	function GroupsPage_VersionExclusive(req, resp, next) {
-		req.groupName = "Version Exclusives";
-		req.pokemonGroupArray = [120, 121, 127, 228, 229, 261, 262, 304, 305,306,345,346,347,348,539,684,685,692,693,716,90,91,138,139,140,141,214,246,247,248,309,310,509,510,538,682,683,690,691,717];
-		next();
-	}
-
-	function GroupsPage_PokeBank(req, resp, next) {
-		req.groupName = "PokeBank Only";
-		req.pokemonGroupArray = [19,20,52,53,109,110,137,151,152,153,154,155,156,157,158,159,160,200,201,233,234,243,244,245,249,250,251,252,253,254,258,259,260,287,288,289,343,344,349,350,351,377,378,379,380,381,382,383,384,385,386,387,388,389,390,391,392,393,394,395,401,402,420,421,427,428,429,431,432,456,457,474,480,481,482,483,484,485,486,487,488,489,490,491,492,493,494,495,496,497,498,499,500,501,502,503,546,547,554,555,562,563,592,593,602,603,604,605,606,626,638,639,640,641,642,643,644,645,646,647,648,649];
-		next();
-	}
-
 	function RenderGroupData(req, resp) {
-		var highChartsData = req.highChartsData,
-			pokemonGroupArray = req.pokemonGroupArray,
-			filterdResults = highChartsData.filterGroupsOfPokemon(pokemonGroupArray),
-			pokemonTable = highChartsData.getPokemonTable(filterdResults);
-
-		pokemonTable.reverse();
-
 		resp.render('data/groupsData', {
-			title: req.groupName,
+			title: req.data.pokemonGroupName,
 			pageState: '',
 			result: req.result,
-			pokemonGroupArray: pokemonGroupArray,
+			pokemonGroupArray: req.data.pokemonGroup,
 			PokemonHash: PokemonHash,
-			trendingPokemonChart: JSON.stringify(highChartsData.getCachedTrendByPokemonIds(pokemonGroupArray)),
-			levelBarChart: JSON.stringify(highChartsData.getCountsByLevels(filterdResults)),
+			trendingPokemonChart: JSON.stringify(req.data.cachedTrendByPokemonIds),
+			levelBarChart: JSON.stringify(req.data.countsByLevels),
 			pokemonList: PokemonList,
 			user: req.user,
-			pokemonTable: pokemonTable,
-			pokemonChart: JSON.stringify(highChartsData.getSortedCountsByPokemon(filterdResults)),
-			quickstats: highChartsData.getQuickStats(filterdResults)
+			pokemonTable: req.data.sortedCountsByPokemon,
+			pokemonChart: JSON.stringify(req.data.sortedCountsByPokemon),
+			quickstats: req.data.quickstats
 		});
 	}
-
 	function getVisualizeData(req, resp){
-		var highChartsData = req.highChartsData,
-			pokemonIdList = highChartsData.getPokemonIds();
-
 		resp.render('visualize', {
 			title: 'Visualized Wonder Trades',
 			pageState: '',
-			pokemonIdList: pokemonIdList
+			pokemonIdList: req.data.randomSample
 		});
 	}
-
 	function RecentWonderTradesPage(req, res) {
-		dataStore.lrange('userTable' , 0, -1, function(error, result){
-			var userTable = new UserTableModel(result),
-				highChartsData = req.highChartsData;
-
-			res.render('wondertrade/index', {
-				wondertrades: highChartsData.deserializedResults.slice(0, 100),
-				title: 'Wonder Trade List',
-				pokemonHash: PokemonHash,
-				countryHash: CountryHash,
-				pageState: '',
-				userTable: userTable,
-				user: req.user
-			});
+		res.render('wondertrade/index', {
+			wondertrades: req.highChartsData.deserializedResults.slice(0, 100),
+			title: 'Wonder Trade List',
+			pokemonHash: PokemonHash,
+			countryHash: CountryHash,
+			pageState: '',
+			userTable: req.userTable,
+			user: req.user
 		});
 	}
 
-	app.get('/data', setupHighChartsData, OverviewPage);
+	app.get('/data', setupHighChartsData, HighCharts.getSortedCountsByCountries, HighCharts.getSortedCountsByPokemon, OverviewPage);
 
 	// Setup the highcharts Object before each /data/* request
 	app.get('/data/*', setupHighChartsData);
-	app.get('/data/pokemon', PokemonPage);
-	app.get('/data/pokemon/:pokemonId', PokemonByIdPage);
-	app.get('/data/regions', RegionsPage);
-	app.get('/data/regions/:regionCode', RegionByIdPage);
-	app.get('/data/nicknames', NicknamesPage);
-	app.get('/data/hiddenAbilities', HiddenAbilitiesPage);
-	app.get('/data/perfectIV', PerfectIVPage);
-	app.get('/data/shiny', ShinyPage);
-	app.get('/data/gender', GenderPage);
-	app.get('/data/levels', LevelsPage);
-	app.get('/data/levels/:pokemonLevel', LevelPage);
-	app.get('/data/dates', DatesPage);
-	app.get('/data/dates/:submissionDate', DatePage);
-	app.get('/data/daterange/:startDate/now', DateRangePage);
-	app.get('/data/daterange/:startDate/:endDate', DateRangePage);
-	app.get('/data/likes', LikesPage);
-	app.get('/data/time', TimePage);
-	app.get('/data/recent', RecentWonderTradesPage);
+
+	app.get('/data/pokemon', HighCharts.getTopPokemon, HighCharts.getCountsByLevels, HighCharts.getSortedCountsByCountries,
+		HighCharts.getSortedCountsByPokemon, HighCharts.getQuickStats, HighCharts.setPokemonGroup, HighCharts.getCachedTrendByPokemonIds, PokemonPage);
+
+	app.get('/data/pokemon/:pokemonId', HighCharts.setSubsetByPokemonId, HighCharts.getCountsByLevels,
+		HighCharts.getNicknamesByResultSet, HighCharts.getSortedCountsByCountries, HighCharts.getCountsByGender,
+		HighCharts.getCachedTrendByPokemonId, HighCharts.getQuickStats, PokemonByIdPage);
+
+	app.get('/data/regions', HighCharts.getSortedCountsByCountries, RegionsPage);
+
+	app.get('/data/regions/:regionCode', HighCharts.setSubsetByRegionId, HighCharts.getCountsByGender, HighCharts.getDataCountsSplitByTime,
+		HighCharts.getSortedCountsByPokemon, HighCharts.getCountsBySubRegions, HighCharts.getQuickStats, RegionByIdPage);
+
+	app.get('/data/hiddenAbilities', HighCharts.setSubsetByHiddenAbilities, HighCharts.getCountsByLevels,
+		HighCharts.getSortedCountsByCountries, HighCharts.getSortedCountsByPokemon, HighCharts.getQuickStats, HiddenAbilitiesPage);
+
+	app.get('/data/perfectIV', HighCharts.setSubsetByPerfectIV, HighCharts.getCountsByLevels,
+		HighCharts.getSortedCountsByCountries, HighCharts.getSortedCountsByPokemon, HighCharts.getQuickStats, PerfectIVPage);
+
+	app.get('/data/shiny', HighCharts.setSubsetByShinyPokemon, HighCharts.getCountsByLevels,
+		HighCharts.getSortedCountsByCountries, HighCharts.getSortedCountsByPokemon, HighCharts.getQuickStats, ShinyPage);
+
+	app.get('/data/gender', HighCharts.getGenderData, GenderPage);
+
+	app.get('/data/levels', HighCharts.getCountsByLevels, LevelsPage);
+	app.get('/data/levels/:pokemonLevel', HighCharts.setSubsetByPokemonLevel, HighCharts.getSortedCountsByPokemon,
+		HighCharts.getSortedCountsByCountries, HighCharts.getQuickStats, HighCharts.getCountsByGender, LevelPage);
+	app.get('/data/dates', HighCharts.getCachedQuickStatsTrendsByDates, DatesPage);
+	app.get('/data/dates/:submissionDate', setupUserTableData, HighCharts.setSubsetBySubmissionDate,
+		HighCharts.getSortedCountsByPokemon, HighCharts.getSortedCountsByCountries, HighCharts.getQuickStats,
+		HighCharts.getCountsByUserIdAndUserTableFormatted, DatePage);
+
+	app.get('/data/daterange/:startDate/:endDate', setupUserTableData, HighCharts.setSubsetByDateRange,
+		HighCharts.getSortedCountsByPokemon, HighCharts.getSortedCountsByCountries, HighCharts.getCountsByGender,
+		HighCharts.getCountsByUserIdAndUserTableFormatted,
+		HighCharts.getQuickStats, DateRangePage);
+
+	app.get('/data/likes', HighCharts.getCommunityLikes, LikesPage);
+	app.get('/data/time', HighCharts.getDataSplitByTime, HighCharts.getQuickStatsTrendsByTime, TimePage);
+	app.get('/data/recent', setupUserTableData, RecentWonderTradesPage);
 
 	app.get('/groups', GroupsPage);
-	app.get('/groups/*', setupHighChartsData);
-	app.get('/groups/eeveelutions', GroupsPage_Eevee, RenderGroupData);
-	app.get('/groups/starters', GroupsPage_Starters, RenderGroupData);
-	app.get('/groups/trade-evos', GroupsPage_TradeEvos, RenderGroupData);
-	app.get('/groups/trio-legendarys', GroupsPage_TrioLegendary, RenderGroupData);
-	app.get('/groups/version-exclusives', GroupsPage_VersionExclusive, RenderGroupData);
-	app.get('/groups/pokebanks', GroupsPage_PokeBank, RenderGroupData);
+	app.get('/groups/:groupName', setupHighChartsData, HighCharts.setPokemonGroup, HighCharts.setSubsetByPokemonGroup,
+		HighCharts.getSortedCountsByPokemon, HighCharts.getCachedTrendByPokemonIds, HighCharts.getCountsByLevels,
+		HighCharts.getQuickStats, RenderGroupData);
 
+	app.get('/originalTrainers', setupHighChartsData, HighCharts.getCachedOriginalTrainers, OTPage);
+	app.get('/originalTrainers/:trainerId', setupHighChartsData, HighCharts.getOriginalTrainersById, OTPageById);
 
-	app.get('/originalTrainers', setupHighChartsData, OTPage);
-	app.get('/originalTrainers/:trainerId', setupHighChartsData, OTPageById);
+	app.get('/users/*', setupHighChartsData, setupUserTableData);
+	app.get('/users/:userId', findRedditUserName, HighCharts.setSubsetByUserId,
+		HighCharts.getSortedCountsByPokemon, HighCharts.getSortedCountsByCountries, HighCharts.getCountsByGender,
+		HighCharts.getSubmissionDates, HighCharts.getTrendsByDate, HighCharts.getCountsByLevels,
+		HighCharts.getQuickStats, UserIdPage);
+	app.get('/users/:userId/date/:submissionDate', HighCharts.setSubsetByUserIdAndSubmissionDate,
+		HighCharts.getSortedCountsByPokemon, HighCharts.getSortedCountsByCountries, HighCharts.getCountsByGender,
+		HighCharts.getCountsByLevels, HighCharts.getQuickStats,
+		UserIdDatePage);
 
-	// TODO: setupUserTableData, and consider moving this to a separate controller?
-	app.get('/users/*', setupHighChartsData);
-	app.get('/users/:userId', UserIdPage);
-	app.get('/users/:userId/date/:submissionDate', UserIdDatePage);
-
-	app.get('/visualize', setupHighChartsData, getVisualizeData);
+	app.get('/visualize', setupHighChartsData, HighCharts.getRandomSample, getVisualizeData);
 };

--- a/controllers/highCharts.js
+++ b/controllers/highCharts.js
@@ -1,0 +1,322 @@
+/**
+ * This controller handles returning high chart data asynchronously
+ */
+
+function setSubsetByHiddenAbilities(req, res, next) {
+	req.highChartsData.getResultsWithHiddenAbilities(function(result){
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetByPerfectIV(req, res, next) {
+	req.highChartsData.getResultsWithPerfectIV(function(result){
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetByShinyPokemon(req, res, next) {
+	req.highChartsData.getResultsWithShinyPokemon(function(result){
+		req.currentSubset = result;
+		next();
+	});
+}
+
+function setSubsetByPokemonId (req, res, next) {
+	var pokemonId = req.params.pokemonId;
+	req.highChartsData.getResultsByPokemonId(pokemonId, function(result) {
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetByPokemonLevel (req, res, next) {
+	var pokemonLevel = req.params.pokemonLevel;
+	req.highChartsData.getResultsByPokemonLevel(pokemonLevel, function(result) {
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetByRegionId (req, res, next) {
+	var regionId = req.params.regionCode;
+	req.highChartsData.getResultsByRegionId(regionId, function(result) {
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetByUserId (req, res, next) {
+	var userId = req.params.userId;
+	req.highChartsData.getResultsByUserId(userId, function(result) {
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetByUserIdAndSubmissionDate (req, res, next) {
+	var userId = req.params.userId,
+		submissionDate = req.params.submissionDate;
+
+	req.highChartsData.getResultsByUserIdAndSubmissionDate(userId, submissionDate, function(result) {
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetBySubmissionDate (req, res, next) {
+	var submissionDate = req.params.submissionDate;
+	req.highChartsData.getResultsBySubmissionDate(submissionDate, function(result) {
+		req.currentSubset = result;
+		next();
+	});
+}
+function setSubsetByDateRange (req, res, next) {
+	var startDate = req.params.startDate,
+		endDate = req.params.endDate || 'now';
+	req.highChartsData.getResultsByDateRange(startDate, endDate, function(result) {
+		req.currentSubset = result;
+		next();
+	});
+}
+
+function setPokemonGroup (req, res, next) {
+
+	var groupName = req.params.groupName || '',
+		groupMap = {
+			'eeveelutions': {
+				name: 'Eeveelutions',
+				pokemon: [134, 135, 136, 196, 197, 470, 471, 700]
+			},
+			'starters': {
+				name: 'Starters',
+				pokemon: [1, 4, 7, 152, 155, 158, 252, 255, 258, 387, 390, 393, 495, 498, 501, 650, 653, 656]
+			},
+			'trade-evos': {
+				name: 'Trade Evolutions',
+				pokemon: [64, 67, 75, 93, 525, 533, 708, 711]
+			},
+			'trio-legendarys': {
+				name: 'Trio Legendarys',
+				pokemon: [144, 145, 146, 243, 244, 245, 377, 378, 379, 480, 481, 482, 638, 639, 640]
+			},
+			'version-exclusives': {
+				name: 'Version Exclusives',
+				pokemon: [120, 121, 127, 228, 229, 261, 262, 304, 305,306,345,346,347,348,539,684,685,692,693,716,90,91,138,139,140,141,214,246,247,248,309,310,509,510,538,682,683,690,691,717]
+			},
+			'pokebanks': {
+				name: 'PokeBank Only',
+				pokemon: [19,20,52,53,109,110,137,151,152,153,154,155,156,157,158,159,160,200,201,233,234,243,244,245,249,250,251,252,253,254,258,259,260,287,288,289,343,344,349,350,351,377,378,379,380,381,382,383,384,385,386,387,388,389,390,391,392,393,394,395,401,402,420,421,427,428,429,431,432,456,457,474,480,481,482,483,484,485,486,487,488,489,490,491,492,493,494,495,496,497,498,499,500,501,502,503,546,547,554,555,562,563,592,593,602,603,604,605,606,626,638,639,640,641,642,643,644,645,646,647,648,649]
+			}
+		},
+		pokemonGroup = groupMap[groupName];
+
+	if (pokemonGroup) {
+		req.data.pokemonGroupName = pokemonGroup.name;
+		req.data.pokemonGroup = pokemonGroup.pokemon;
+		return next();
+	}
+
+	req.data.pokemonGroup = req.data.topPokemon;
+	next();
+}
+
+function setSubsetByPokemonGroup(req, res, next) {
+	req.highChartsData.filterGroupsOfPokemon(req.data.pokemonGroup, function(result){
+		req.currentSubset = result;
+		next();
+	});
+}
+
+function getSortedCountsByCountries(req, resp, next) {
+	req.highChartsData.getSortedCountsByCountries(req.currentSubset, function(err, result) {
+		req.data.sortedCountsByCountries = result;
+		next();
+	});
+}
+function getSortedCountsByPokemon(req, res, next) {
+	req.highChartsData.getSortedCountsByPokemon(req.currentSubset, function(err, result) {
+		req.data.sortedCountsByPokemon = result;
+		next();
+	});
+}
+function getCountsByLevels (req, res, next) {
+	req.highChartsData.getCountsByLevels(req.currentSubset, function(err, result) {
+		req.data.countsByLevels = result;
+		next();
+	});
+}
+function getQuickStats (req, res, next) {
+	req.highChartsData.getQuickStats (req.currentSubset, function(err, result) {
+		req.data.quickstats = result;
+		next();
+	});
+}
+function getTopPokemon (req, res, next) {
+	req.highChartsData.getTopPokemon (5, function(err, result) {
+		req.data.topPokemon = result.map(function(pkmn){
+			return parseInt(pkmn[2], 10);
+		});
+		next();
+	});
+}
+function getNicknamesByResultSet (req, res, next) {
+	req.highChartsData.getNicknamesByResultSet (req.currentSubset, function(err, result) {
+		req.data.nicknames = result;
+		next();
+	});
+}
+function getCountsByGender (req, res, next) {
+	req.highChartsData.getCountsByGender (req.currentSubset, function(err, result) {
+		req.data.countsByGender = result;
+		next();
+	});
+}
+
+function getCachedTrendByPokemonId (req, res, next) {
+	req.highChartsData.getCachedTrendByPokemonId (req.params.pokemonId, function(err, result) {
+		req.data.cachedTrendByPokemonId = result;
+		next();
+	});
+}
+function getCachedTrendByPokemonIds (req, res, next) {
+	req.highChartsData.getCachedTrendByPokemonIds (req.data.pokemonGroup, function(err, result) {
+		req.data.cachedTrendByPokemonIds = result;
+		next();
+	});
+}
+
+function getCachedTrendsByDate (req, res, next) {
+	req.highChartsData.getCachedTrendsByDate (function(err, result) {
+		req.data.cachedTrendsByDate = result;
+		next();
+	});
+}
+
+function getDataCountsSplitByTime(req, res, next) {
+	req.highChartsData.getDataCountsSplitByTime(req.currentSubset, function(err, result) {
+		req.data.dataCountsSplitByTime = result;
+		next();
+	});
+}
+
+function getCountsBySubRegions(req, res, next) {
+	req.highChartsData.getCountsBySubRegions(req.currentSubset, function(err, result) {
+		req.data.countsBySubRegions = result;
+		next();
+	});
+}
+
+function getCachedQuickStatsTrendsByDates(req, res, next) {
+	req.highChartsData.getCachedQuickStatsTrendsByDates(function(err, result) {
+		req.data.cachedQuickStatsTrendsByDates = result;
+		next();
+	});
+}
+
+function getTrendsByDate(req, res, next) {
+	req.highChartsData.getTrendsByDate(req.currentSubset, function(err, result) {
+		req.data.trendsByDate = result;
+		next();
+	});
+}
+
+function getCountsByUserIdAndUserTableFormatted(req, res, next) {
+	req.highChartsData.getCountsByUserIdAndUserTableFormatted(req.currentSubset, req.userTable, function(err, result) {
+		req.data.countsByUserIdAndUserTableFormatted = result;
+		next();
+	});
+}
+
+function getDataSplitByTime(req, res, next) {
+	req.highChartsData.getDataSplitByTime(req.currentSubset, function(err, result) {
+		req.data.dataSplitByTime = result;
+		next();
+	});
+}
+
+function getQuickStatsTrendsByTime(req, res, next){
+	req.highChartsData.getQuickStatsTrendsByTime(req.data.dataSplitByTime, function(err, result) {
+		req.data.quickStatsTrendsByTime = result;
+		next();
+	});
+}
+
+function getCommunityLikes(req, res, next) {
+	req.highChartsData.getCommunityLikes(req.currentSubset, function(err, result) {
+		req.data.communityLikes = result;
+		next();
+	});
+}
+
+function getCachedOriginalTrainers(req, res, next) {
+	req.highChartsData.getCachedOriginalTrainers(function(err, result) {
+		req.data.cachedOriginalTrainers = result;
+		next();
+	});
+}
+
+function getOriginalTrainersById(req, res, next) {
+	var trainerId = req.params.trainerId;
+	req.highChartsData.getOriginalTrainersById(trainerId, function(err, result) {
+		req.data.originalTrainersById = result;
+		next();
+	});
+}
+
+function getSubmissionDates(req, res, next) {
+	req.highChartsData.getSubmissionDates(req.currentSubset, function(err, result) {
+		req.data.submissionDates = result;
+		next();
+	});
+}
+
+function getRandomSample(req, res, next){
+	req.highChartsData.getRandomSample(req.currentSubset, function(err, result) {
+		req.data.randomSample = result;
+		next();
+	});
+}
+
+function getGenderData(req, res, next){
+	req.highChartsData.getCachedGenderData(function(err, result) {
+		req.data.genderData = result;
+		next();
+	});
+}
+
+// es6 format
+module.exports = {
+	setSubsetByHiddenAbilities: setSubsetByHiddenAbilities,
+	setSubsetByPerfectIV: setSubsetByPerfectIV,
+	setSubsetByShinyPokemon: setSubsetByShinyPokemon,
+	setSubsetByPokemonGroup: setSubsetByPokemonGroup,
+
+	setSubsetByPokemonId: setSubsetByPokemonId,
+	setSubsetByPokemonLevel: setSubsetByPokemonLevel,
+	setSubsetByRegionId: setSubsetByRegionId,
+	setSubsetByUserId: setSubsetByUserId,
+	setSubsetByUserIdAndSubmissionDate: setSubsetByUserIdAndSubmissionDate,
+	setSubsetBySubmissionDate: setSubsetBySubmissionDate,
+	setSubsetByDateRange: setSubsetByDateRange,
+
+	setPokemonGroup: setPokemonGroup,
+
+	getSortedCountsByCountries: getSortedCountsByCountries,
+	getSortedCountsByPokemon: getSortedCountsByPokemon,
+	getCountsByLevels: getCountsByLevels,
+	getQuickStats: getQuickStats,
+	getTopPokemon: getTopPokemon,
+	getNicknamesByResultSet: getNicknamesByResultSet,
+	getCountsByGender: getCountsByGender,
+	getCachedTrendByPokemonId: getCachedTrendByPokemonId,
+	getCachedTrendByPokemonIds: getCachedTrendByPokemonIds,
+	getCachedTrendsByDate: getCachedTrendsByDate,
+	getDataCountsSplitByTime: getDataCountsSplitByTime,
+	getCountsBySubRegions: getCountsBySubRegions,
+	getCachedQuickStatsTrendsByDates: getCachedQuickStatsTrendsByDates,
+	getTrendsByDate: getTrendsByDate,
+	getDataSplitByTime: getDataSplitByTime,
+	getQuickStatsTrendsByTime: getQuickStatsTrendsByTime,
+	getCommunityLikes: getCommunityLikes,
+	getCachedOriginalTrainers: getCachedOriginalTrainers,
+	getOriginalTrainersById: getOriginalTrainersById,
+	getSubmissionDates: getSubmissionDates,
+	getRandomSample: getRandomSample,
+	getGenderData: getGenderData,
+	getCountsByUserIdAndUserTableFormatted: getCountsByUserIdAndUserTableFormatted
+};

--- a/index.js
+++ b/index.js
@@ -79,7 +79,12 @@ Date.prototype.customFormatDate = function(){
 
 // After all other routes are init, we can now check for 404s.
 app.use(function(req, res, next){  
-  res.render('404', { status: 404, url: req.url, title: 'Page Not Found', user: req.user, stateMessage: '', pageState: '' });
+  res.render('404', { status: 404, url: req.url, title: '404, Page Not Found', user: req.user, stateMessage: '', pageState: '' });
+});
+
+app.use(function(error, req, res, next) {
+	console.log(req.originalUrl, ':', error.stack);
+	res.render('500', { status: 500, url: req.url, title: 'Something broke :(', user: req.user, stateMessage: '', pageState: '' });
 });
 
 

--- a/models/HighChartsData.js
+++ b/models/HighChartsData.js
@@ -1,5 +1,44 @@
-var _ = require('underscore'),
-	lupus = require('lupus');
+var async = require('async');
+
+function formatDateFromString(dateString){
+	var formattedDate = dateString.split('-'),
+		utcDate = Date.UTC(formattedDate[0], (parseInt(formattedDate[1])-1), formattedDate[2]);
+	return utcDate;
+}
+
+/**
+ * Build an empty pokemon-date-count object, presetting the chart to a 0'd values for each pokemon
+ * @returns {
+ *  pokemonId: {
+ *      dateString: dateCount
+ *  }
+ * }
+ */
+function EmptyCountsByPokemonByDate () {
+
+	var pokemonList = {},
+		PokemonList,
+		i;
+
+	PokemonList = function() {
+		var startDate = new Date(),
+			endDate = new Date();
+
+		startDate.setMonth(startDate.getMonth()-1);
+		while(startDate < endDate) {
+			this[startDate.customFormatDate()] = 0;
+			startDate.setDate(startDate.getDate()+1);
+		}
+		return this;
+	};
+
+
+	for (i = 0;i<=718;i++) {
+		pokemonList[i] = new PokemonList();
+	}
+
+	return pokemonList;
+}
 
 var HighChartsData = function(pokemonHash, countryHash) {
 
@@ -14,6 +53,7 @@ HighChartsData.prototype.refreshData = function(jsonResults) {
 
 	console.log('Refreshing HighCharts Data: ' + (new Date()));
 	console.time('Finished Refreshing HighCharts Data');
+
 	try {
 		var jsonString = '[' + jsonResults + ']';
 		jsonString = jsonString.replace('\'', '');
@@ -23,22 +63,20 @@ HighChartsData.prototype.refreshData = function(jsonResults) {
 
 		this.cachePageResults();
 	} catch (e) {
-
+		console.log(e);
 		console.log('There was an error parsing the redis results. Falling back to the previous version.');
 
 		var deserializedResults = [],
 			self = this;
 
-		lupus(0, jsonResults.length, function(n) {
-			currentWonderTrade = jsonResults[n];
+		async.each(jsonResults, function(currentWonderTrade) {
 
 			try {
 				deserializedResults.push(JSON.parse(currentWonderTrade));
 			} catch (e) {
 				console.log('There was a problem with WonderTrade: ', currentWonderTrade);
 			}
-
-		}, function(){
+		}, function(err){
 			self.deserializedResults = deserializedResults;
 			console.timeEnd('Finished Refreshing HighCharts Data');
 
@@ -48,274 +86,318 @@ HighChartsData.prototype.refreshData = function(jsonResults) {
 };
 
 HighChartsData.prototype.cachePageResults = function () {
+	var self = this;
 	console.time('Highcharts Page Cache has been reset');
-	this.cachedData.pokemonTrends = this.getCountTrendsByPokemon();
-	this.cachedData.originalTrainers = this.getOriginalTrainers();
-	this.cachedData.dateTrend = this.getTrendsByDate();
-	this.cachedData.dateTrendQuickstats = this.getQuickStatsTrendsByDates();
+	this.getCountTrendsByPokemon(function(err, result) {
+		self.formatCountTrendsByPokemon(result, function(err, formattedResult){
+			self.cachedData.pokemonTrends = formattedResult;
+		});
+	});
+	this.getOriginalTrainers(function(err, result){
+		self.cachedData.originalTrainers = result;
+	});
+	this.getTrendsByDate(null, function(err, result){
+		self.cachedData.dateTrend = result;
+	});
+	this.getQuickStatsTrendsByDates(function(err, result){
+		self.cachedData.dateTrendQuickstats = result;
+	});
+	this.getGenderData(function(err, result){
+		self.cachedData.genderData = result;
+	});
 	console.timeEnd('Highcharts Page Cache has been reset');
 };
 
-HighChartsData.prototype.getSortedCountsByCountries = function(resultSet){
+HighChartsData.prototype.getSortedCountsByCountries = function(resultSet, callback){
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
 
-	var trainerCountries = _.countBy(resultSet, 'trainerCountry'),
-		countryChart = [],
-		countryHash = this.countryHash;
-	_.each(trainerCountries, function(countryCount, countryId) {
-		countryChart.push([countryHash[countryId], countryCount]);
-	});
+	var countryHash = this.countryHash,
+		countryCountMap = {},
+		country,
+		countryCount;
 
-	countryChart = _.sortBy(countryChart, function(itr){
-		return itr[1];
-	});
+	function createCountryCountMap(taskFinished) {
+		async.each(resultSet, function(result, eachCallback){
 
-	return countryChart;
+			country = result.trainerCountry;
+			countryCount = countryCountMap[country];
+			countryCountMap[country] = (countryCount) ? (countryCount + 1) : 1;
+			eachCallback();
+		}, taskFinished);
+	}
+
+	function createCountryCountArray(taskFinished) {
+		async.map(Object.keys(countryCountMap), function (countryId, countryCallback) {
+			countryCallback(null, [countryHash[countryId], countryCountMap[countryId], countryId]);
+		}, taskFinished);
+	}
+
+	function sortCountryCountArray(countryCountArray, taskFinished) {
+		async.sortBy(countryCountArray, function(country, sortCallback){
+			sortCallback(null, country[1]);
+		}, taskFinished);
+	}
+
+	async.waterfall([
+		createCountryCountMap,
+		createCountryCountArray,
+		sortCountryCountArray
+	], function(err, result){
+		callback(err, result);
+	});
 };
 
-HighChartsData.prototype.getRegionsTable = function(resultSet){
+HighChartsData.prototype.getRandomSample = function(resultSet, callback) {
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
 
-	var trainerCountries = _.countBy(resultSet, 'trainerCountry'),
-		countryChart = [],
-		countryHash = this.countryHash;
-	_.each(trainerCountries, function(countryCount, countryId) {
-		countryChart.push({id: countryId, name: countryHash[countryId], count: countryCount});
-	});
-
-	countryChart = _.sortBy(countryChart, function(itr){
-		return itr.count;
-	});
-
-	return countryChart;
-};
-
-HighChartsData.prototype.getNicknamesTable = function() {
-	return _.filter(this.deserializedResults, function(wonderTrade){
-		if(wonderTrade.pokemonNickname) {
-			return wonderTrade;
+	async.times(1000,
+		function (n, whilstBack) {
+			var index = ~~(Math.random() * resultSet.length);
+			whilstBack(null, resultSet[index].pokemonId);
+		},
+		function (err, result) {
+			callback(err, result);
 		}
-	});
+	);
 };
 
-HighChartsData.prototype.getPokemonTable = function(resultSet) {
+HighChartsData.prototype.getSortedCountsByPokemon = function(resultSet, callback){
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
-	var pokemonResults = _.countBy(resultSet, 'pokemonId'),
-		pokemonTable = [],
-		pokemonHash = this.pokemonHash;
-	_.each(pokemonResults, function(pokemonCount, pokemonId) {
-		pokemonTable.push({id:pokemonId, name: pokemonHash[pokemonId], count: pokemonCount});
-	});
 
-	pokemonTable = _.sortBy(pokemonTable, function(itr){
-		return itr.count;
-	});
+	var pokemonHash = this.pokemonHash,
+		pokemonCountMap = {},
+		pokemonCount;
 
-	return pokemonTable;
+	function createPokemonCountsMap (taskFinished) {
+		async.each(resultSet, function(wonderTrade, wonderTradeCallback) {
+			pokemonCount = pokemonCountMap[wonderTrade.pokemonId];
+			pokemonCountMap[wonderTrade.pokemonId] = pokemonCount ? pokemonCount + 1 : 1;
+			wonderTradeCallback();
+		}, taskFinished)
+	}
+
+	function createPokemonCountsArray (taskFinished) {
+		async.map(Object.keys(pokemonCountMap), function (pokemonId, itemCallback) {
+			itemCallback(null, [pokemonHash[pokemonId], pokemonCountMap[pokemonId], pokemonId]);
+		}, taskFinished);
+	}
+
+	function sortPokemonCountArray(pokemonCountArray, taskFinished) {
+		async.sortBy(pokemonCountArray, function(pokemon, sortCallback){
+			sortCallback(null, pokemon[1]);
+		}, taskFinished);
+	}
+
+	async.waterfall([
+		createPokemonCountsMap,
+		createPokemonCountsArray,
+		sortPokemonCountArray
+	], callback);
 };
 
-HighChartsData.prototype.getPokemonIds = function(resultSet) {
+HighChartsData.prototype.getCountsByUserIdAndUserTableFormatted = function(resultSet, userTable, callback){
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
-	var pokemonResults = _.pluck(resultSet, 'pokemonId');
+	var userIdCountMap = {},
+		userId,
+		userIdCount;
 
-	return _.sample(pokemonResults, 1000);
-};
-
-HighChartsData.prototype.getSortedCountsByPokemon = function(resultSet){
-	if(!resultSet) {
-		resultSet = this.deserializedResults;
+	function createUserIdMap(taskFinished) {
+		async.each(resultSet, function(wonderTrade, wonderTradeCallback){
+			userId = wonderTrade.userId;
+			userIdCount = userIdCountMap[userId];
+			userIdCountMap[userId] = userIdCount ? userIdCount + 1 : 1;
+			wonderTradeCallback();
+		}, taskFinished);
 	}
-	var pokemonByIds = _.countBy(resultSet, 'pokemonId'),
-		pokemonChart = [],
-		pokemonHash = this.pokemonHash;
-	_.each(pokemonByIds, function(pokemonByIdCount, pokemonId) {
-		pokemonChart.push([pokemonHash[pokemonId], pokemonByIdCount]);
-	});
 
-	pokemonChart = _.sortBy(pokemonChart, function(itr){
-		return itr[1];
-	});
-
-	return pokemonChart;
-};
-
-HighChartsData.prototype.getSortedCountsByPokemonId = function(resultSet){
-	if(!resultSet) {
-		resultSet = this.deserializedResults;
+	function createUserIdArray(taskFinished) {
+		async.map(Object.keys(userIdCountMap), function(userId, userIdCallback){
+			userIdCallback(null, [ userTable[userId], userIdCountMap[userId], userId ]);
+		}, taskFinished);
 	}
-	var pokemonByIds = _.countBy(resultSet, 'pokemonId'),
-		pokemonChart = [];
-	_.each(pokemonByIds, function(pokemonByIdCount, pokemonId) {
-		pokemonChart.push([pokemonId, pokemonByIdCount]);
-	});
 
-	pokemonChart = _.sortBy(pokemonChart, function(itr){
-		return itr[1];
-	});
-
-	return pokemonChart;
-};
-
-/* @param resultSet What is returned from the redis datastore
- * @param userTable A Json table of valid users.
- */
-
-HighChartsData.prototype.getCountsByUserIdAndUserTable = function(resultSet, userTable){
-	if(!resultSet) {
-		resultSet = this.deserializedResults;
+	function sortUserIdArray(userIdArray, taskFinished) {
+		async.sortBy(userIdArray, function(user, sortCallback){
+			sortCallback(null, user[1] * -1);
+		}, taskFinished);
 	}
-	var countsByUserId = _.countBy(resultSet, 'userId');
-	_.each(countsByUserId, function(userIdCount, userId){
-		if(userTable[userId]) {
-			userTable[userId].count = userIdCount;
-		}
-	});
 
-	userTable = _.sortBy(userTable, 'count');
-	userTable.reverse();
-
-	return userTable;
+	async.waterfall([
+		createUserIdMap,
+		createUserIdArray,
+		sortUserIdArray
+	], callback);
 
 };
 
-HighChartsData.prototype.getCountsByUserIdAndUserTableFormatted = function(resultSet, userTable){
-	if(!resultSet) {
-		resultSet = this.deserializedResults;
-	}
-	var formattedResults = [];
+HighChartsData.prototype.getResultsByPokemonId = function(pokemonId, callback) {
 
-	var countsByUserId = _.countBy(resultSet, 'userId');
-	_.each(countsByUserId, function(userIdCount, userId){
-		if(userTable[userId] && userIdCount > 0) {
-			formattedResults.push([ userTable[userId], userIdCount ]);
-		}
-	});
-
-	formattedResults = _.sortBy(formattedResults, function(userResult){
-		return userResult[1];
-	});
-
-	return formattedResults;
-
-};
-
-HighChartsData.prototype.getResultsByPokemonId = function(pokemonId) {
-	pokemonId = parseInt(pokemonId);
+	pokemonId = parseInt(pokemonId, 10);
 	if(pokemonId > 0 && pokemonId <= 719) {
-		return _.where(this.deserializedResults, {pokemonId: parseInt(pokemonId)});
+		return async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+			filterBack(parseInt(wonderTrade.pokemonId, 10) === pokemonId);
+		}, callback);
 	}
-	return [];
+
+	callback([]);
 };
 
-HighChartsData.prototype.getResultsWithHiddenAbilities = function() {
-	return _.where(this.deserializedResults, {hasHiddenAbility: true});
+HighChartsData.prototype.getResultsWithHiddenAbilities = function(callback) {
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+		filterBack(wonderTrade.hasHiddenAbility);
+	}, callback);
 };
 
-HighChartsData.prototype.getResultsWithPerfectIV = function() {
-	return _.where(this.deserializedResults, {hasPerfectIV: true});
+HighChartsData.prototype.getResultsWithPerfectIV = function(callback) {
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+		filterBack(wonderTrade.hasPerfectIV);
+	}, callback);
 };
 
-HighChartsData.prototype.getResultsWithShinyPokemon = function() {
-	return _.where(this.deserializedResults, {isShiny: true});
+HighChartsData.prototype.getResultsWithShinyPokemon = function(callback) {
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+		filterBack(wonderTrade.isShiny);
+	}, callback);
 };
 
-HighChartsData.prototype.getResultsByPokemonLevel = function(pokemonLevel) {
+HighChartsData.prototype.getResultsByPokemonLevel = function(pokemonLevel, callback) {
 	pokemonLevel = parseInt(pokemonLevel);
 	if(pokemonLevel > 0 && pokemonLevel <= 100) {
-		return _.where(this.deserializedResults, {level: pokemonLevel});
+		return async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+			filterBack(wonderTrade.level === pokemonLevel);
+		}, callback);
 	}
-	return [];
+	callback([]);
 };
 
-HighChartsData.prototype.getResultsByRegionId = function(regionId) {
+HighChartsData.prototype.getResultsByRegionId = function(regionId, callback) {
 	if(this.countryHash[regionId]) {
-		return _.where(this.deserializedResults, {trainerCountry: regionId});
+		return async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+			filterBack(wonderTrade.trainerCountry === regionId);
+		}, callback);
 	}
-	return [];
+	callback([]);
 };
 
-HighChartsData.prototype.getResultsByUserId = function(userId) {
-	return _.where(this.deserializedResults, {userId: parseInt(userId)});
+HighChartsData.prototype.getResultsByUserId = function(userId, callback) {
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+		filterBack(wonderTrade.userId === parseInt(userId));
+	}, callback);
 };
 
-HighChartsData.prototype.getResultsByUserIdAndSubmissionDate = function(userId, submissionDate) {
-	return _.where(this.deserializedResults, {userId: parseInt(userId), date: submissionDate});
+HighChartsData.prototype.getResultsByUserIdAndSubmissionDate = function(userId, submissionDate, callback) {
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+		filterBack(wonderTrade.userId === parseInt(userId) && wonderTrade.date === submissionDate);
+	}, callback);
 };
 
-HighChartsData.prototype.getResultsBySubmissionDate = function(submissionDate) {
-	return _.where(this.deserializedResults, {date: submissionDate});
+HighChartsData.prototype.getResultsBySubmissionDate = function(submissionDate, callback) {
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+		filterBack(wonderTrade.date === submissionDate);
+	}, callback);
 };
 
-HighChartsData.prototype.getResultsByGender = function(gender) {
-	return _.where(this.deserializedResults, {trainerGender: gender});
+HighChartsData.prototype.getResultsByGender = function(gender, callback) {
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack){
+		filterBack(wonderTrade.trainerGender === gender);
+	}, callback);
 };
 
-HighChartsData.prototype.getResultsByDate = function(date){
-	return _.where(this.deserializedResults, {date: date});
-};
-
-HighChartsData.prototype.getResultsByDateRange = function(startDate, endDate){
-	if (!endDate || endDate === 'Now') {
+HighChartsData.prototype.getResultsByDateRange = function(startDate, endDate, callback){
+	if (!endDate || endDate === 'now') {
 		var tempDate = new Date();
 		endDate = tempDate.getFullYear()+'-'+(tempDate.getMonth()+1)+'-'+tempDate.getDate();
 	}
-	return _.filter(this.deserializedResults, function(result){
-		var resultDate =result.date;
-		return (resultDate >= startDate && resultDate <= endDate);
-	});
+	async.filter(this.deserializedResults, function(wonderTrade, filterBack) {
+		var resultDate =wonderTrade.date;
+		filterBack(resultDate >= startDate && resultDate <= endDate);
+	}, callback);
 };
 
-HighChartsData.prototype.getNicknamesByResultSet = function(resultSet){
+HighChartsData.prototype.getNicknamesByResultSet = function(resultSet, callback){
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
-	var reduced = _.filter(resultSet, function(pokemon){
-		return pokemon.pokemonNickname !== '';
-	});
-	return _.pluck(reduced, 'pokemonNickname');
-};
 
-HighChartsData.prototype.getCountsBySubRegions = function(regionSet) {
-	var subRegions = _.countBy(regionSet, function(wonderTrade){
-		return wonderTrade.trainerCountrySub1;
-	});
-
-	var subRegionsChart = [];
-	_.each(subRegions, function(subregionCount, regionName){
-		if(regionName) {
-			subRegionsChart.push([regionName, subregionCount]);
+	async.waterfall([
+		function(taskComplete) {
+			async.filter(resultSet, function(wonderTrade, filterBack) {
+				filterBack(wonderTrade.pokemonNickname !== '');
+			}, function(result) {taskComplete(null, result);});
+		},
+		function(nicknamedResults, taskComplete) {
+			async.map(nicknamedResults, function(wonderTrade, cb){
+				cb(null, wonderTrade.pokemonNickname);
+			}, callback);
 		}
-	});
-
-	subRegionsChart = _.sortBy(subRegionsChart, function(itr){
-		return itr[1];
-	});
-
-	return subRegionsChart;
+	], callback)
 };
 
-HighChartsData.prototype.getCountsByGender = function(resultSet){
+HighChartsData.prototype.getCountsBySubRegions = function(regionSet, callback) {
+
+	var regionCountMap = {},
+		subregion,
+		subregionCount;
+
+	function createRegionCountMap(taskFinished){
+		async.each(regionSet, function(wondertrade, wondertradeCallback){
+			subregion = wondertrade.trainerCountrySub1;
+			if (subregion) {
+				subregionCount = regionCountMap[subregion];
+				regionCountMap[subregion] = subregionCount ? subregionCount + 1 : 1;
+			}
+			wondertradeCallback();
+		}, taskFinished);
+	}
+
+	function createRegionCountArray(taskFinished){
+		async.map(Object.keys(regionCountMap), function(regionName, arrayCallback){
+			arrayCallback(null, [regionName, regionCountMap[regionName]]);
+		}, taskFinished);
+	}
+
+	function sortRegionCountArray(regionCounts, taskFinished) {
+		async.sortBy(regionCounts, function(region, sortCallback){
+			sortCallback(null, region[1]);
+		}, taskFinished);
+	}
+
+	async.waterfall([
+		createRegionCountMap,
+		createRegionCountArray,
+		sortRegionCountArray
+	], callback);
+};
+
+HighChartsData.prototype.getCountsByGender = function(resultSet, callback) {
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
-	var trainerGender = _.countBy(resultSet, 'trainerGender');
-	return [["Guys", trainerGender.male], ["Girls", trainerGender.female]];
+	var trainerGender = {
+		male: 0,
+		female: 0
+	};
+	async.each(resultSet, function(wonderTrade, wonderTradeCallback){
+		trainerGender[wonderTrade.trainerGender]++;
+		wonderTradeCallback();
+	}, function(err){
+		callback(err, [["Guys", trainerGender.male], ["Girls", trainerGender.female]])
+	});
 };
 
-HighChartsData.prototype.getCountsByLevels = function(resultSet){
+HighChartsData.prototype.getCountsByLevels = function(resultSet, callback) {
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
-	var pokemonLevels = _.countBy(resultSet, 'level'),
-		levelsChart = [],
+	var levelsChart = [],
 		levelsChartFormatted = [{
 			name: 'Levels',
 			data: []
@@ -325,388 +407,518 @@ HighChartsData.prototype.getCountsByLevels = function(resultSet){
 		levelsChart.push([i, 0]);
 	}
 
-	_.each(pokemonLevels, function(levelCount, level){
-		var currentLevel = parseInt(level);
+	async.each(resultSet, function(wonderTrade, wonderTradeCallback){
+		var currentLevel = parseInt(wonderTrade.level);
 
 		if(currentLevel >= 1 && currentLevel <= 100) {
-			levelsChart[currentLevel-1][1]+=levelCount;
+			levelsChart[currentLevel-1][1]++;
 		}
+		wonderTradeCallback();
+	}, function(err){
+		levelsChartFormatted[0].data = levelsChart;
+		callback(err, levelsChartFormatted)
 	});
-
-	levelsChartFormatted[0].data = levelsChart;
-
-	return levelsChartFormatted;
 };
 
 /**
  * Retrieve the countTrend data for all pokemon.
  * @returns {1: [...], 2: []}, where 1/2 are pokemon ids, and the arrays are formatted highchart objects
  */
-HighChartsData.prototype.getCountTrendsByPokemon = function(){
+HighChartsData.prototype.getCountTrendsByPokemon = function(callback){
 
-	var resultSet = this.deserializedResults,
-		pokemonHash = this.pokemonHash,
-		pokemonGroupedByDate = {},
-		trendingPokemonChart = {},
-		totalCountsByDate = {},
-		context = this;
+	var resultSet = this.deserializedResults;
 
 
-	var currentWT,
-		currentPkmn,
+	/**
+	 * Before we were making multiple passes around the resultSet, it was very unoptimal.
+	 *
+	 * Our revision will do the following for each individual wonder trade.
+	 *
+	 * The proposed format will be:
+	 *
+	 *  pokemonId: {
+	 *      dateString: count
+	 *  }
+	 *
+	 * Example:
+	 *
+	 *  25: {
+	 *      2015-01-15: 10
+	 *      2015-01-14: 3
+	 *  },
+	 *  all: {
+	 *      2015-01-15: 100
+	 *      2015-01-14: 37
+	 *  }
+	 *
+	 *  We start by filling the object with each pokemon and all dates for the past month.
+	 *
+	 **/
+
+	var countsByDate = new EmptyCountsByPokemonByDate(),
+		totalPokemon = countsByDate['0'],
 		currentDate;
-	for(var wonderTrade in resultSet) {
-		currentWT = resultSet[wonderTrade];
-		currentPkmn = currentWT.pokemonId;
-		currentDate = currentWT.date;
 
-		if (!pokemonGroupedByDate[currentPkmn]) {
-			pokemonGroupedByDate[currentPkmn] = {};
+	async.each(resultSet, function(wonderTrade, resultCallback){
+		var currentPokemon = countsByDate[wonderTrade.pokemonId];
+		currentDate = wonderTrade.date;
+
+		if ( typeof totalPokemon[currentDate] !== "undefined" ) {
+			currentPokemon[currentDate]++;
+			totalPokemon[currentDate]++;
 		}
-		pokemonGroupedByDate[currentPkmn][currentDate] = pokemonGroupedByDate[currentPkmn][currentDate] ?
-			(pokemonGroupedByDate[currentPkmn][currentDate] + 1) : 1;
-	}
+		resultCallback();
+	}, function(){
+		callback(null, countsByDate);
+	});
+};
 
-	// Generic Literal Object to hold pokemon data
-	var pokemonData;
+HighChartsData.prototype.formatCountTrendsByPokemon = function(result, callback) {
 
-	var startDate = new Date(),
+	var keys = [],
+		pokemonHash = this.pokemonHash,
+		startDate = new Date(),
 		endDate = new Date(),
-		fullDateRange = [],
-		countPercent;
+		dateRange = [];
 
-	// And now.. we review each pokemon, and add their date/counts
-	_.each(pokemonGroupedByDate, function(pokemonTradesByDate, pokemonId) {
-		// Generic Literal Object to hold pokemon data
-		pokemonData = {
-			name: pokemonHash[pokemonId],
-			data: []
-		};
-
-		startDate = new Date();
-		endDate = new Date();
-		fullDateRange = [];
-
-		startDate.setMonth(startDate.getMonth()-1);
-		while(startDate < endDate) {
-			fullDateRange.push([context.formatDateFromString(startDate.customFormatDate()), 0]);
-			startDate.setDate(startDate.getDate()+1);
-		}
-
-		_.each(pokemonTradesByDate, function(dateFieldCount, dateField){
-			if (!totalCountsByDate[dateField]) {
-				totalCountsByDate[dateField] = (context.getResultsByDate(dateField)).length;
-			}
-
-			countPercent = parseFloat((dateFieldCount/totalCountsByDate[dateField]*100).toFixed(2));
-
-			_.each(fullDateRange, function(tempDate){
-				if(context.formatDateFromString(dateField) === tempDate[0]) {
-					tempDate[1] = countPercent;
-				}
-			});
-		});
-
-		trendingPokemonChart[pokemonId] = fullDateRange;
-
-	});
-
-	return trendingPokemonChart;
-};
-
-// Go back to the cache to retrieve the highchart data for an individual pokemon
-HighChartsData.prototype.getCachedTrendByPokemonId = function(pokemonId) {
-
-	return [{
-		name: this.pokemonHash[pokemonId],
-		data: this.cachedData.pokemonTrends[pokemonId]
-	}];
-};
-
-// Go back to the cache to retrieve the highchart data for a set of pokemon
-HighChartsData.prototype.getCachedTrendByPokemonIds = function(pokemonIdArray) {
-	var trends = [],
-		currentId;
-	for(var i= 0,max=pokemonIdArray.length;i<max;i++) {
-		currentId = pokemonIdArray[i];
-
-		trends.push({
-			name: this.pokemonHash[currentId],
-			data: this.cachedData.pokemonTrends[currentId]
-		})
-	}
-	return trends;
-};
-
-HighChartsData.prototype.getSubmissionDates = function(resultSet) {
-	var submissionDates = [],
-		context = this;
-
-	if(!resultSet) {
-		resultSet = this.deserializedResults;
-	}
-
-	var wonderTradesByDate = _.groupBy(resultSet, function(wonderTrade){
-		return wonderTrade.date;
-	});
-
-	_.each(wonderTradesByDate, function(dateCount, dateString) {
-		var dateFieldCount = _.size(dateCount),
-			submission = {
-				dateString: dateString,
-				formattedDate: context.formatDateFromString(dateString),
-				count: dateFieldCount
-			};
-		submissionDates.push(submission);
-	});
-
-	submissionDates = _.sortBy(submissionDates, function(data) {
-		return data.formattedDate;
-	});
-
-	return submissionDates;
-};
-
-HighChartsData.prototype.getTrendsByDate = function(resultSet) {
-	var trendChart = {
-			name: "Wonder Trades",
-			data: []
-		},
-		context = this;
-
-	var startDate = new Date(2013, 10, 21),
-		endDate = new Date(),
-		fullDateRange = [];
+	startDate.setMonth(startDate.getMonth()-1);
 	while(startDate < endDate) {
-		fullDateRange.push([context.formatDateFromString(startDate.customFormatDate()), 0]);
+		dateRange.push(startDate.customFormatDate());
 		startDate.setDate(startDate.getDate()+1);
 	}
 
+	// Fill the key list with pokemon ids
+	for(var i =1; i<=718;i++) {
+		keys.push(i);
+	}
+
+	async.map(keys, function(pokemonId, formattedCountTrend) {
+
+		var pokemonData = {
+				name: pokemonHash[pokemonId],
+				data: []
+			},
+			pokemon = result[pokemonId],
+			currentDate,
+			percentage;
+
+		for(var i=0;i<dateRange.length;i++) {
+
+			currentDate = dateRange[i];
+			percentage = (parseFloat((pokemon[currentDate]/ (result['0'][currentDate]) *100).toFixed(2))) || 0;
+			pokemonData.data.push([
+				formatDateFromString(currentDate),
+				percentage
+			]);
+		}
+
+		formattedCountTrend(null, pokemonData)
+	}, callback);
+};
+
+// Go back to the cache to retrieve the highchart data for an individual pokemon
+HighChartsData.prototype.getCachedTrendByPokemonId = function(pokemonId, callback) {
+
+	var self = this;
+
+	function formattedCallback(callback) {
+		var pokemonDataId = pokemonId ? (pokemonId - 1) : '',
+			pokemon = self.cachedData.pokemonTrends[pokemonDataId] || {},
+			data = (pokemon && pokemon.data) || [];
+
+		callback(null, [{
+			name: (self.pokemonHash[pokemonId] || ''),
+			data: data
+		}]);
+	}
+
+	if (this.cachedData.pokemonTrends) {
+		return formattedCallback(callback);
+	}
+
+	// fallback
+	this.getCountTrendsByPokemon(function(err, result) {
+		self.formatCountTrendsByPokemon(result, function(err, formattedResult){
+			self.cachedData.pokemonTrends = formattedResult;
+			formattedCallback(callback);
+		});
+	});
+};
+
+// Go back to the cache to retrieve the highchart data for a set of pokemon
+HighChartsData.prototype.getCachedTrendByPokemonIds = function(pokemonIdArray, callback) {
+
+	var self = this;
+	async.map(pokemonIdArray, function(pokemonId, pokemonCallback){
+		pokemonCallback(null, {
+			name: self.pokemonHash[pokemonId],
+			data: self.cachedData.pokemonTrends[pokemonId - 1].data
+		})
+	}, callback);
+};
+
+HighChartsData.prototype.getSubmissionDates = function(resultSet, callback) {
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
 
-	var wonderTradesByDate = _.groupBy(resultSet, function(wonderTrade){
-		return wonderTrade.date;
-	});
+	var dateStringMap = {},
+		dateString,
+		dateStringCount;
 
-	_.each(wonderTradesByDate, function(dateCount, dateString) {
-		var dateFieldCount = _.size(dateCount);
-		_.each(fullDateRange, function(tempDate){
-			if(context.formatDateFromString(dateString) === tempDate[0]) {
-				tempDate[1] = dateFieldCount;
-			}
+	function createSubmissionDatesMap(taskFinished) {
+		async.each(resultSet, function(wondertrade, wondertradeCallback){
+			dateString = wondertrade.date;
+			dateStringCount = dateStringMap[dateString];
+			dateStringMap[dateString] = dateStringCount ? dateStringCount + 1 : 1;
+			wondertradeCallback();
+		},taskFinished)
+	}
+	function createSubmissionDatesArray(taskFinished) {
+		async.map(Object.keys(dateStringMap), function(dateString, arrayCallback){
+			arrayCallback(null, {
+				dateString: dateString,
+				formattedDate: formatDateFromString(dateString),
+				count: dateStringMap[dateString]
+			});
+		}, taskFinished);
+	}
+	function sortSubmissionDatesArray(submissionArray, taskFinished) {
+		async.sortBy(submissionArray, function(submission, sortCallback){
+			sortCallback(null, submission.formattedDate);
+		}, taskFinished)
+	}
+
+	async.waterfall([
+		createSubmissionDatesMap,
+		createSubmissionDatesArray,
+		sortSubmissionDatesArray
+	], callback);
+};
+
+HighChartsData.prototype.getTrendsByDate = function(resultSet, callback) {
+
+	if(!resultSet) {
+		resultSet = this.deserializedResults;
+	}
+
+	var startDate = new Date(2013, 10, 21),
+		endDate = new Date(),
+		fullDateRange = [],
+		dateStringMap = {},
+		dateString,
+		dateStringCount;
+
+	while(startDate < endDate) {
+		fullDateRange.push([formatDateFromString(startDate.customFormatDate()), 0]);
+		startDate.setDate(startDate.getDate()+1);
+	}
+
+	function createSubmissionDatesMap(taskFinished) {
+		async.each(resultSet, function(wondertrade, wondertradeCallback){
+			dateString = formatDateFromString(wondertrade.date);
+			dateStringCount = dateStringMap[dateString];
+			dateStringMap[dateString] = dateStringCount ? dateStringCount + 1 : 1;
+			wondertradeCallback();
+		},taskFinished)
+	}
+	function createDatesArray(taskFinished) {
+		async.map(fullDateRange, function(dateStringObject, arrayCallback){
+			dateStringObject[1] = dateStringMap[dateStringObject[0]] || 0;
+			arrayCallback(null, dateStringObject);
+		}, taskFinished);
+	}
+
+	function formatOutput(formattedDateValues, taskFinished) {
+		taskFinished(null, {
+			name: "Wonder Trades",
+			data: formattedDateValues
 		});
-	});
+	}
 
-	trendChart.data = fullDateRange;
-
-	return trendChart;
+	async.waterfall([
+		createSubmissionDatesMap,
+		createDatesArray,
+		formatOutput
+	], callback);
 };
 
-HighChartsData.prototype.getCachedTrendsByDate = function() {
-	return this.cachedData.dateTrend;
+HighChartsData.prototype.getCachedTrendsByDate = function(callback) {
+	callback(null, this.cachedData.dateTrend);
 };
 
-HighChartsData.prototype.getTopPokemon = function(limit){
+HighChartsData.prototype.getTopPokemon = function(limit, callback){
 
 	var startDate = new Date(),
-		endDate = new Date();
+		endDate = new Date(),
+		self = this;
 
 	startDate.setMonth(startDate.getMonth()-1);
 
-	var lastMonthsResults = this.getResultsByDateRange(startDate.customFormatDate(), endDate.customFormatDate()),
-		countTrends = this.getSortedCountsByPokemonId(lastMonthsResults);
-	countTrends = countTrends.reverse();
-	return _.first(countTrends,limit);
+	this.getResultsByDateRange(startDate.customFormatDate(), endDate.customFormatDate(), function(lastMonthsResults) {
+		self.getSortedCountsByPokemon(lastMonthsResults, function(err, countTrends) {
+			countTrends = countTrends.reverse();
+			callback(null, countTrends.slice(0, limit));
+		});
+	});
 };
 
-HighChartsData.prototype.getCommunityLikes = function(resultSet){
-	var communityOpinion = {
-		likes: [],
-		dislikes: []
-	};
+HighChartsData.prototype.getCommunityLikes = function(resultSet, callback){
+
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
 
-	var wonderTradesByPokemon = _.groupBy(resultSet, function(wonderTrade){
-		return wonderTrade.pokemonId;
-	}),
-		pokemonHash = this.pokemonHash;
+	var pokemonHash = this.pokemonHash;
 
-	_.each(wonderTradesByPokemon, function(pokemonList, pokemonId){
-		var likedCounts = _.countBy(pokemonList, function(pokemon){
-			if(pokemon.liked === "like" || pokemon.liked === "dislike"){
-				return pokemon.liked;
-			}
-		});
+	var pokemonMap = {},
+		pokemonIds = [],
+		pokemon,
+		pokemonId,
+		opinionCount;
 
-		// Preset 0 likes and dislikes
-		likedCounts = _.extend({like: 0, dislike: 0}, likedCounts);
+	for(var i=0;i<719;i++){
+		pokemonIds.push(i);
+	}
 
-		var likes = likedCounts.like,
-			dislikes = likedCounts.dislike;
-
-		if(likes || dislikes) {
-			var totalOpinions = likes+dislikes,
-				likePercentage = (likes / (totalOpinions)*100).toFixed(2),
-				pokemonLikesObject = {
+	function createPokemonLikesMap (taskFinished) {
+		async.each(resultSet, function(wondertrade, wondertradeCallback){
+			pokemonId = wondertrade.pokemonId;
+			pokemon = pokemonMap[pokemonId - 1];
+			if (!pokemon) {
+				pokemonMap[pokemonId - 1] = {
 					id: pokemonId,
 					name: pokemonHash[pokemonId],
-					percentage: likePercentage,
-					count: totalOpinions,
-					likes: likes,
-					dislikes: dislikes
+					percentage: 0,
+					count: 0,
+					likes: 0,
+					dislikes: 0
 				};
-
-			if(pokemonLikesObject.count > 2) {
-				if(likePercentage > 80) {
-					communityOpinion.likes.push(pokemonLikesObject);
-				} else if (likePercentage < 20) {
-					communityOpinion.dislikes.push(pokemonLikesObject);
-				}
+				pokemon = pokemonMap[pokemonId - 1];
 			}
-		}
-	});
+			if(wondertrade.liked === "like"){
+				pokemon.likes++;
+			} else if(wondertrade.liked === "dislike") {
+				pokemon.dislikes++;
+			}
+			pokemon.count++;
+			opinionCount = pokemon.likes + pokemon.dislikes;
+			pokemon.percentage = (pokemon.likes / (opinionCount)*100).toFixed(2);
 
-	communityOpinion.likes = _.sortBy(communityOpinion.likes, function(pokemonData){
-		return parseInt(pokemonData.dislikes)-parseInt(pokemonData.likes);
-	});
-	communityOpinion.dislikes = _.sortBy(communityOpinion.dislikes, function(pokemonData){
-		return parseInt(pokemonData.likes)-parseInt(pokemonData.dislikes);
-	});
+			wondertradeCallback();
+		}, taskFinished);
+	}
 
-	return communityOpinion;
+	function createPokemonLikesArray (taskFinished) {
+		async.map(pokemonIds, function(pokemonId, pokemonIdCallback){
+			if (pokemonMap[pokemonId]) {
+				return pokemonIdCallback(null, pokemonMap[pokemonId]);
+			}
+			pokemonIdCallback(null, {
+				id: pokemonId,
+				name: pokemonHash[pokemonId],
+				percentage: 0,
+				count: 0,
+				likes: 0,
+				dislikes: 0
+			});
+		}, taskFinished)
+	}
+
+	function sortPokemonLikesArray (pokemonMapArray, taskFinished) {
+		async.sortBy(pokemonMapArray, function(pokemon, sortCallback) {
+			sortCallback(null, parseInt(pokemon.likes - pokemon.dislikes) * -1);
+		}, taskFinished);
+	}
+
+	function filterPokemonLikesArray(pokemonLikesArray, taskFinish) {
+		async.filter(pokemonLikesArray, function(pokemon, filterCallback){
+			filterCallback(( pokemon.count > 2 && (pokemon.percentage > 80 || pokemon.percentage < 20 ) ));
+		}, function(result) {
+			taskFinish(null, result);
+		});
+	}
+
+	function formatOutput(sortedPokemonMap, taskFinished){
+		var size = sortedPokemonMap.length,
+			dislikes = sortedPokemonMap.slice(size - 20, size);
+		dislikes = dislikes.reverse();
+		taskFinished(null, {
+			likes: sortedPokemonMap.slice(0, 20),
+			dislikes: dislikes
+		});
+	}
+
+	async.waterfall([
+		createPokemonLikesMap,
+		createPokemonLikesArray,
+		filterPokemonLikesArray,
+		sortPokemonLikesArray,
+		formatOutput
+	], callback);
 };
 
-HighChartsData.prototype.getOriginalTrainers = function(){
+HighChartsData.prototype.getOriginalTrainers = function(callback){
 
 	var resultSet = this.deserializedResults,
-		originalTrainers = {};
+		originalTrainers = {},
+		originalTrainer,
+		trainerId,
+		trainerName;
 
-	var wonderTradesByTrainerId = _.groupBy(resultSet, function(wonderTrade){
-		return wonderTrade.trainerId;
-	});
-
-	_.each(wonderTradesByTrainerId, function(wonderTrades, key){
-		if(key && key !== "undefined"){
-			var wonderTradeNames = _.groupBy(wonderTrades, function(wondertrade){return wondertrade.trainerName;});
-			originalTrainers[key] = {
-				"names": _.keys(wonderTradeNames),
-				"count": wonderTrades.length
-			};
+	async.each(resultSet, function(wondertrade, wondertradeCallback){
+		trainerId = wondertrade.trainerId;
+		trainerName = wondertrade.trainerName;
+		originalTrainer = originalTrainers[trainerId];
+		if (trainerId && trainerName) {
+			if (!originalTrainer) {
+				originalTrainers[trainerId] = {
+					"names": [trainerName],
+					"count": 1
+				}
+			} else {
+				originalTrainer.names.push(trainerName);
+				originalTrainer.count++;
+			}
 		}
-	});
 
-	return originalTrainers;
+		wondertradeCallback();
+	}, function(err){
+		callback(err, originalTrainers);
+	});
 };
 
-HighChartsData.prototype.getCachedOriginalTrainers = function(){
-	return this.cachedData.originalTrainers;
+HighChartsData.prototype.getCachedOriginalTrainers = function(callback){
+	callback(null, this.cachedData.originalTrainers);
 };
 
-HighChartsData.prototype.getOriginalTrainersById = function(trainerId){
-	var resultSet = _.where(this.deserializedResults, {"trainerId": trainerId}),
-		originalTrainers = {};
+HighChartsData.prototype.getOriginalTrainersById = function(trainerId, callback){
+	var resultSet = this.deserializedResults,
+		originalTrainers = {},
+		trainerName;
 
-	var wonderTradesByTrainerName = _.groupBy(resultSet, function(wonderTrade){
-		return wonderTrade.trainerName;
-	});
-
-	_.each(wonderTradesByTrainerName, function(wonderTrades, key){
-		if(key && key !== "undefined"){
-			originalTrainers[key] = wonderTrades;
+	async.each(resultSet, function(wondertrade, wondertradeCallback){
+		if(wondertrade.trainerId === trainerId) {
+			trainerName = wondertrade.trainerName;
+			if (!originalTrainers[trainerName]) {
+				originalTrainers[trainerName] = [];
+			}
+			originalTrainers[trainerName].push(wondertrade);
 		}
+		wondertradeCallback();
+	}, function(err){
+		callback(err, originalTrainers);
 	});
-
-	return originalTrainers;
 };
 
-HighChartsData.prototype.getPercentageByAttribute = function(attribute, resultSet) {
+HighChartsData.prototype.getPercentageByAttribute = function(attribute, resultSet, callback) {
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
 
-	var countsByAttribute = _.countBy(resultSet, attribute),
-		totalSize = _.size(resultSet);
-	if(!countsByAttribute.true || countsByAttribute.true === "NaN") {
-		countsByAttribute.true = 0;
-	}
-	var percentage = ((countsByAttribute.true)/totalSize*100).toFixed(2);
-
-	return parseFloat(percentage);
+	async.filter(resultSet, function(wondertrade, wondertradeCallback){
+		wondertradeCallback(wondertrade[attribute]);
+	}, function(result){
+		var subsetSize = result.length || 0,
+			totalSize = resultSet.length,
+			percentage = ((subsetSize)/totalSize*100).toFixed(2);
+		callback(null, parseFloat(percentage));
+	});
 };
 
-HighChartsData.prototype.getShinyPercentage = function(resultSet) {
-	return this.getPercentageByAttribute('isShiny', resultSet);
+HighChartsData.prototype.getShinyPercentage = function(resultSet, callback) {
+	this.getPercentageByAttribute('isShiny', resultSet, callback);
 };
 
-HighChartsData.prototype.getItemPercentage = function(resultSet) {
-	return this.getPercentageByAttribute('hasItem', resultSet);
+HighChartsData.prototype.getItemPercentage = function(resultSet, callback) {
+	this.getPercentageByAttribute('hasItem', resultSet, callback);
 };
 
-HighChartsData.prototype.getPokerusPercentage = function(resultSet) {
-	return this.getPercentageByAttribute('hasPokerus', resultSet);
+HighChartsData.prototype.getPokerusPercentage = function(resultSet, callback) {
+	this.getPercentageByAttribute('hasPokerus', resultSet, callback);
 };
 
-HighChartsData.prototype.getHiddenAbilityPercentage = function(resultSet) {
-	return this.getPercentageByAttribute('hasHiddenAbility', resultSet);
+HighChartsData.prototype.getHiddenAbilityPercentage = function(resultSet, callback) {
+	this.getPercentageByAttribute('hasHiddenAbility', resultSet, callback);
 };
 
-HighChartsData.prototype.getPerfectIVPercentage = function(resultSet) {
-	return this.getPercentageByAttribute('hasPerfectIV', resultSet);
+HighChartsData.prototype.getPerfectIVPercentage = function(resultSet, callback) {
+	this.getPercentageByAttribute('hasPerfectIV', resultSet, callback);
 };
 
-HighChartsData.prototype.getEggMovePercentage = function(resultSet) {
-	return this.getPercentageByAttribute('hasEggMove', resultSet);
+HighChartsData.prototype.getEggMovePercentage = function(resultSet, callback) {
+	this.getPercentageByAttribute('hasEggMove', resultSet, callback);
 };
 
-HighChartsData.prototype.getLikePercentage = function(resultSet){
-	var likeCounts = _.countBy(resultSet, function(wonderTrade){
-			return wonderTrade.liked;
-		}),
-		likes = likeCounts.like || 0,
-		dislikes = likeCounts.dislike || 0,
-		total = likes+dislikes;
+HighChartsData.prototype.getLikePercentage = function(resultSet, callback){
+	var likes = 0,
+		dislikes = 0;
 
-	if(total > 0) {
-		var percentage = (likes/(total)*100).toFixed(2);
-		return parseFloat(percentage);
-	}
-
-	return "- ";
+	async.each(resultSet, function(wondertrade, wondertradeCallback) {
+		var liked = wondertrade.liked;
+		if (liked === 'like') {
+			likes++;
+		} else if(liked === 'dislike') {
+			dislikes++;
+		}
+		wondertradeCallback();
+	}, function(){
+		var total = likes+dislikes;
+		if(total > 0) {
+			var percentage = (likes/(total)*100).toFixed(2);
+			return callback(null, parseFloat(percentage));
+		}
+		callback(null, " ");
+	});
 };
 
-HighChartsData.prototype.getQuickStats = function(resultSet) {
+HighChartsData.prototype.getQuickStats = function(resultSet, callback) {
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
-	return {
-		resultCount: _.size(resultSet),
-		totalCount: _.size(this.deserializedResults),
-		resultPercent: (_.size(resultSet)/_.size(this.deserializedResults)*100).toFixed(2),
-		shinyPercentage: this.getShinyPercentage(resultSet),
-		hiddenAbilityPercentage: this.getHiddenAbilityPercentage(resultSet),
-		itemPercentage: this.getItemPercentage(resultSet),
-		pokerusPercentage: this.getPokerusPercentage(resultSet),
-		eggMovePercentage: this.getEggMovePercentage(resultSet),
-		perfectIvPercentage: this.getPerfectIVPercentage(resultSet),
-		likePercentage: this.getLikePercentage(resultSet)
-	};
+
+	var self = this;
+	async.parallel({
+		shinyPercentage: this.getShinyPercentage.bind(this, resultSet),
+		hiddenAbilityPercentage: this.getHiddenAbilityPercentage.bind(this, resultSet),
+		itemPercentage: this.getItemPercentage.bind(this, resultSet),
+		pokerusPercentage: this.getPokerusPercentage.bind(this, resultSet),
+		eggMovePercentage: this.getEggMovePercentage.bind(this, resultSet),
+		perfectIvPercentage: this.getPerfectIVPercentage.bind(this, resultSet),
+		likePercentage: this.getLikePercentage.bind(this, resultSet)
+
+	}, function(err, results){
+		var resultCount = resultSet.length,
+			totalCount = self.deserializedResults.length;
+
+		callback(err, {
+			resultCount: resultCount,
+			totalCount: totalCount,
+			resultPercent: (resultCount/totalCount * 100 ).toFixed(2) || 0,
+			shinyPercentage: results.shinyPercentage,
+			hiddenAbilityPercentage: results.hiddenAbilityPercentage,
+			itemPercentage: results.itemPercentage,
+			pokerusPercentage: results.pokerusPercentage,
+			eggMovePercentage: results.eggMovePercentage,
+			perfectIvPercentage: results.perfectIvPercentage,
+			likePercentage: results.likePercentage
+		});
+	});
+
+
 };
 
-HighChartsData.prototype.filterGroupsOfPokemon = function(pokemonGroupArray) {
-	return _.filter(this.deserializedResults, function(wonderTrade){
-		return _.contains(pokemonGroupArray, parseInt(wonderTrade.pokemonId));
-	});
+HighChartsData.prototype.filterGroupsOfPokemon = function(pokemonGroupArray, callback) {
+	async.filter(this.deserializedResults, function(wondertrade, wondertradeCallback){
+		wondertradeCallback(pokemonGroupArray.indexOf(wondertrade.pokemonId) !== -1);
+	}, callback);
 };
 
 /**
  * Show percentages of hiddenAbilities, perfectIVs.. based on dates.
  */
-HighChartsData.prototype.getQuickStatsTrendsByDates = function() {
-	var startDate = new Date(2013, 10, 21),
+HighChartsData.prototype.getQuickStatsTrendsByDates = function(callback) {
+	var startDate = new Date(),
 		endDate = new Date(),
 		shinyJSON = {
 			name: "Shiny<br/> Pokemon",
@@ -733,72 +945,101 @@ HighChartsData.prototype.getQuickStatsTrendsByDates = function() {
 			shortName: "Perfect IV",
 			data: []
 		},
-		highchartsTrendsChart;
+		self = this;
 
-	while(startDate < endDate) {
-		var dateString = startDate.customFormatDate(),
-			formattedDateResults = this.getResultsByDate(dateString),
-			utcDateString = this.formatDateFromString(dateString),
-			quickStatsByDate = this.getQuickStats(formattedDateResults);
+	startDate.setMonth(startDate.getMonth()-12);
 
-		// Populate the Highcharts data
-		if(quickStatsByDate.resultCount > this.dailyThreshold) {
-			shinyJSON.data.push([utcDateString, quickStatsByDate.shinyPercentage]);
-			hiddenAbilityJSON.data.push([utcDateString, quickStatsByDate.hiddenAbilityPercentage]);
-			pokerusJSON.data.push([utcDateString, quickStatsByDate.pokerusPercentage]);
-			eggMoveJSON.data.push([utcDateString, quickStatsByDate.eggMovePercentage]);
-			perfectIvJSON.data.push([utcDateString, quickStatsByDate.perfectIvPercentage]);
+	async.whilst(
+		function () {
+			return (startDate < endDate);
+		},
+		function (dateCallback) {
+
+			var dateString = startDate.customFormatDate(),
+				utcDateString = formatDateFromString(dateString);
+
+			self.getResultsBySubmissionDate(dateString, function(formattedDateResults){
+				self.getQuickStats(formattedDateResults, function(err, quickStatsByDate) {
+
+					// Populate the Highcharts data
+					if(quickStatsByDate.resultCount > self.dailyThreshold) {
+						shinyJSON.data.push([utcDateString, quickStatsByDate.shinyPercentage]);
+						hiddenAbilityJSON.data.push([utcDateString, quickStatsByDate.hiddenAbilityPercentage]);
+						pokerusJSON.data.push([utcDateString, quickStatsByDate.pokerusPercentage]);
+						eggMoveJSON.data.push([utcDateString, quickStatsByDate.eggMovePercentage]);
+						perfectIvJSON.data.push([utcDateString, quickStatsByDate.perfectIvPercentage]);
+					}
+
+					startDate.setDate(startDate.getDate()+1);
+
+					setTimeout( function() {
+						dateCallback();
+					}, 0 );
+				});
+			});
+		},
+		function (err) {
+			callback(err, [shinyJSON, hiddenAbilityJSON, pokerusJSON, eggMoveJSON, perfectIvJSON]);
 		}
+	);
+};
 
-		startDate.setDate(startDate.getDate()+1);
+HighChartsData.prototype.getCachedQuickStatsTrendsByDates = function(callback) {
+	if (this.cachedData.dateTrendQuickstats) {
+		return callback(null, this.cachedData.dateTrendQuickstats);
 	}
-
-	highchartsTrendsChart = [shinyJSON, hiddenAbilityJSON, pokerusJSON, eggMoveJSON, perfectIvJSON];
-
-	return highchartsTrendsChart;
-
+	callback(null, []);
 };
 
-HighChartsData.prototype.getCachedQuickStatsTrendsByDates = function() {
-	return this.cachedData.dateTrendQuickstats;
-};
-
-HighChartsData.prototype.getDataSplitByTime = function(resultSet) {
+HighChartsData.prototype.getDataSplitByTime = function(resultSet, callback) {
 	if(!resultSet) {
 		resultSet = this.deserializedResults;
 	}
-	var grouping = _.groupBy(resultSet, function(wonderTrade){
-		if(wonderTrade.time) {
-			return Math.floor(parseInt(wonderTrade.time)/3600);
+
+	var timeGroupMap = {},
+		timeString;
+
+	async.each(resultSet, function(wondertrade, wondertradeCallback){
+		if(wondertrade.time) {
+			timeString = Math.floor(parseInt(wondertrade.time)/3600);
+			if (timeGroupMap[timeString] && timeGroupMap[timeString].length) {
+				timeGroupMap[timeString].push(wondertrade);
+			} else {
+				timeGroupMap[timeString] = [wondertrade];
+			}
 		}
+		wondertradeCallback();
+	}, function(err){
+		callback(err, timeGroupMap);
 	});
-
-	delete grouping["undefined"];
-
-	return grouping;
 };
 
-HighChartsData.prototype.getDataCountsSplitByTime = function(resultSet) {
-	var getFilteredDataByTime = this.getDataSplitByTime(resultSet),
-		getFullDataByTime = this.getDataSplitByTime(),
-		filteredTimes = _.map(getFilteredDataByTime, function(hourGroup){
-			return hourGroup.length;
-		}),
-		fullTimes = _.map(getFullDataByTime, function(hourGroup){
-			return hourGroup.length;
-		}),
-		percentageTimes = _.map(filteredTimes, function(hourGroup, hourName){
-			return (hourGroup / fullTimes[hourName]);
+HighChartsData.prototype.getDataCountsSplitByTime = function(resultSet, callback) {
+
+	var self = this,
+		hours = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23];
+
+	// TODO: clean up
+	this.getDataSplitByTime(resultSet, function(err, getFilteredDataByTime){
+		self.getDataSplitByTime(null, function(err, getFullDataByTime){
+			var filtered = 0,
+				full = 1;
+			async.map(hours, function(hour, hourBack){
+				filtered = (getFilteredDataByTime[hour] && getFilteredDataByTime[hour].length) || 0;
+				full = (getFullDataByTime[hour] && getFullDataByTime[hour].length) || filtered;
+				hourBack(null, (filtered / full));
+			}, function(err, result){
+				callback(err, {
+					name: "Time Trends",
+					data: result
+				});
+			});
 		});
-
-	return {
-		name: "Time Trends",
-		data: percentageTimes
-	};
+	});
 };
 
-HighChartsData.prototype.getQuickStatsTrendsByTime = function(timeGrouping) {
-	// TODO: Dry these JSONs up.
+HighChartsData.prototype.getQuickStatsTrendsByTime = function(timeGrouping, callback) {
+
 	var shinyJSON = {
 			name: "Shiny<br/> Pokemon",
 			shortName: "Shiny Pokemon",
@@ -824,31 +1065,103 @@ HighChartsData.prototype.getQuickStatsTrendsByTime = function(timeGrouping) {
 			shortName: "Perfect IV",
 			data: []
 		},
-		highchartsTrendsChart;
+		hours = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+		self = this;
 
-	for (var hour=0;hour<24;hour++) {
-		var quickStatsByDate = this.getQuickStats(timeGrouping[hour]);
-
-		// Populate the Highcharts data
-		if(quickStatsByDate.resultCount > this.dailyThreshold) {
-			shinyJSON.data.push([hour, quickStatsByDate.shinyPercentage]);
-			hiddenAbilityJSON.data.push([hour, quickStatsByDate.hiddenAbilityPercentage]);
-			pokerusJSON.data.push([hour, quickStatsByDate.pokerusPercentage]);
-			eggMoveJSON.data.push([hour, quickStatsByDate.eggMovePercentage]);
-			perfectIvJSON.data.push([hour, quickStatsByDate.perfectIvPercentage]);
-		}
-	}
-
-	highchartsTrendsChart = [shinyJSON, hiddenAbilityJSON, pokerusJSON, eggMoveJSON, perfectIvJSON];
-
-	return highchartsTrendsChart;
+	async.eachSeries(hours,
+		function(hour, hourCallback) {
+			self.getQuickStats(timeGrouping[hour], function(err, quickStatsByDate){
+				// Populate the Highcharts data
+				if(quickStatsByDate.resultCount > self.dailyThreshold) {
+					shinyJSON.data.push([hour, quickStatsByDate.shinyPercentage]);
+					hiddenAbilityJSON.data.push([hour, quickStatsByDate.hiddenAbilityPercentage]);
+					pokerusJSON.data.push([hour, quickStatsByDate.pokerusPercentage]);
+					eggMoveJSON.data.push([hour, quickStatsByDate.eggMovePercentage]);
+					perfectIvJSON.data.push([hour, quickStatsByDate.perfectIvPercentage]);
+				}
+				hourCallback();
+			});
+		},
+	function(){
+		callback(null, [
+			shinyJSON,
+			hiddenAbilityJSON,
+			pokerusJSON,
+			eggMoveJSON,
+			perfectIvJSON
+		]);
+	});
 
 };
 
-HighChartsData.prototype.formatDateFromString = function(dateString){
-	var formattedDate = dateString.split('-'),
-		utcDate = Date.UTC(formattedDate[0], (parseInt(formattedDate[1])-1), formattedDate[2]);
-	return utcDate;
+HighChartsData.prototype.getGenderData = function(callback) {
+
+	var maleSubset,
+		femaleSubset,
+		self = this;
+
+	async.series([
+		function(taskCallback){
+			self.getResultsByGender('male', function(result){
+				maleSubset = result;
+				taskCallback(null);
+			});
+		},
+		function(taskCallback){
+			self.getQuickStats(maleSubset, taskCallback);
+		},
+		function(taskCallback){
+			self.getSortedCountsByPokemon(maleSubset, taskCallback);
+		},
+		function(taskCallback){
+			self.getSortedCountsByCountries(maleSubset, taskCallback);
+		},
+		function(taskCallback){
+			self.getResultsByGender('female', function(result){
+				femaleSubset = result;
+				taskCallback(null);
+			});
+		},
+		function(taskCallback){
+			self.getQuickStats(femaleSubset, taskCallback);
+		},
+		function(taskCallback){
+			self.getSortedCountsByPokemon(femaleSubset, taskCallback);
+		},
+		function(taskCallback){
+			self.getSortedCountsByCountries(femaleSubset, taskCallback);
+		}
+	], function(err, results){
+
+		var malePokemonChart = results[2],
+			malePokemonLength = malePokemonChart.length,
+			maleTopTen = malePokemonChart.slice((malePokemonLength - 10), malePokemonLength),
+			femalePokemonChart = results[6],
+			femalePokemonLength = femalePokemonChart.length,
+			femaleTopTen = femalePokemonChart.slice((femalePokemonLength  - 10), femalePokemonLength );
+
+		maleTopTen = maleTopTen.reverse();
+		femaleTopTen = femaleTopTen.reverse();
+
+		callback(err, {
+			maleQuickstats: results[1],
+			malePokemonChart: malePokemonChart,
+			maleCountryChart: results[3],
+			femaleQuickstats: results[5],
+			femalePokemonChart: femalePokemonChart,
+			femaleCountryChart: results[7],
+			maleTopTenPokemon: maleTopTen,
+			femaleTopTenPokemon: femaleTopTen
+		});
+	});
+
+};
+
+HighChartsData.prototype.getCachedGenderData = function(callback) {
+	if (this.cachedData.genderData) {
+		return callback(null, this.cachedData.genderData);
+	}
+	this.getGenderData(callback);
 };
 
 module.exports = HighChartsData;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "connect-redis": "~1.4.6",
     "connect-heroku-redis": "~0.1.5",
     "lupus": "0.0.1",
-    "newrelic": "~1.14.3"
+    "newrelic": "~1.14.3",
+    "async": "~0.9.0"
   },
   "engines": {
     "node": "0.10.x",

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,5 +1,5 @@
 <% layout('layout') %>
-<h3>404, Page not found</h3>
+<h3><%= title %> (<%= status %>)</h3>
 <p class="center">This is embarrassing... sorry about this.<br/>  Try the <a href="/">homepage</a>?</p>
 <p class="center">If all else fails, feel free to message me on reddit, my username is TheIronDev.  Thanks!</p>
 

--- a/views/500.ejs
+++ b/views/500.ejs
@@ -1,0 +1,10 @@
+<% layout('layout') %>
+<h3><%= title %> (<%= status %>)</h3>
+<p class="center">The site crashed! :o sorry about this.<br/>  Try the <a href="/">homepage</a>?</p>
+<p class="center">Fortunately the crash has been logged, but feel free to message me on reddit, my username is TheIronDev.  Thanks!</p>
+
+<script>
+	$(document).ready(function(){
+		$('.page-background').addClass('espurr');
+	});
+</script>

--- a/views/data/groups.ejs
+++ b/views/data/groups.ejs
@@ -9,7 +9,6 @@
         <li><a href="/groups/starters">Starters</a></li>
         <li><a href="/groups/trade-evos">Trade-Evolutions</a></li>
         <li><a href="/groups/version-exclusives">X / Y Exclusives</a></li>
-        <li><a href="/groups/pokebanks">PokeBank Only</a></li>
         <li><a href="/groups/trio-legendarys">Trio-Legendarys</a></li>
     </ul>
 </div>

--- a/views/data/regions.ejs
+++ b/views/data/regions.ejs
@@ -1,4 +1,4 @@
-<% layout('../layout') -%>
+<% layout('../layout') %>
 <h3>Region Overview</h3>
 
 <div class="chart-box full-chart" id="region-chart"></div>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -5,7 +5,7 @@
 	<meta name="keywords" content="Pokemon, Wonder Trade, Tyler Stark, The Iron Developer">
 	<meta charset="UTF-8" />
 	<meta name="author" content="Tyler Stark">
-	<meta name="viewport" content="intial-scale=1.0, width=device-width" />
+	<meta name="viewport" content="intial-scale=1.0, width=device-width, user-scalable=no" />
 	<meta property="og:image" content="http://www.wondertradeanalytics.com/images/theIronPokeBall.png"/>
 	<link rel="stylesheet" href="/styles/style.css" />
 	<link rel="stylesheet" href="/styles/sprite.css" />

--- a/views/partials/_pokemon-table.ejs
+++ b/views/partials/_pokemon-table.ejs
@@ -1,8 +1,8 @@
 <div class="pokemon-list chart-box" >
     <h4>Wonder Traded Pokemon</h4>
-    <% for(var pokemon in pokemonTable) { %>
-        <% if(pokemonTable[pokemon].id){ %>
-            <a href="/data/pokemon/<%= pokemonTable[pokemon].id %>"><%= pokemonTable[pokemon].name %> (<%= pokemonTable[pokemon].count %>)</a>
+    <% for(var pokemon = (pokemonTable.length-1), max = 0; pokemon >= max; pokemon--) { %>
+        <% if(pokemonTable[pokemon][2]){ %>
+            <a href="/data/pokemon/<%= pokemonTable[pokemon][2] %>"><%= pokemonTable[pokemon][0] %> (<%= pokemonTable[pokemon][1] %>)</a>
         <% } %>
     <% } %>
 </div>

--- a/views/partials/_regions-table.ejs
+++ b/views/partials/_regions-table.ejs
@@ -6,11 +6,11 @@
         </tr>
     </thead>
     <tbody>
-        <% for(var region in regionsTable) { %>
-            <% if(regionsTable[region].id){ %>
+        <% for(var region = countryList.length - 1, min = 0;region >= min; region--) { %>
+            <% if(countryList[region][2]){ %>
                 <tr>        	
-                    <td><a href="/data/regions/<%= regionsTable[region].id %>"><%= regionsTable[region].name %></a></td>
-                    <td><%= regionsTable[region].count %></td>
+                    <td><a href="/data/regions/<%= countryList[region][2] %>"><%= countryList[region][0] %></a></td>
+                    <td><%= countryList[region][1] %></td>
                 </tr>
             <% } %>
         <% } %>

--- a/views/partials/_user-table.ejs
+++ b/views/partials/_user-table.ejs
@@ -1,18 +1,18 @@
 <ul class="contributor-list">
 	<% for(var user in userTable) { %>
-		<% if(userTable[user].count > 0) {  %>
+		<% if(userTable[user][1] > 0) {  %>
 			<li class="contributor">
 				<div class="name">
-                    <a href="/users/<%= userTable[user].id %>">
-                        <%= userTable[user].username %>
+                    <a href="/users/<%= userTable[user][2] %>">
+                        <%= userTable[user][0] %>
                     </a>
-                    <% if (redditUsers && redditUsers[userTable[user].id] && redditUsers[userTable[user].id].redditUserName) { %>
-                        <a href="http://www.reddit.com/user/<%= redditUsers[userTable[user].id].redditUserName %>">
+                    <% if (redditUsers && redditUsers[userTable[user][2]] && redditUsers[userTable[user][2]].redditUserName) { %>
+                        <a href="http://www.reddit.com/user/<%= redditUsers[userTable[user][2]].redditUserName %>">
                             <img src="/images/reddit.gif" border="0" />
                         </a>
                     <% } %>
                 </div>
-				<div class="count"><%= userTable[user].count %> wonder trades recorded</div>
+				<div class="count"><%= userTable[user][1] %> wonder trades recorded</div>
 			</li>
 		<% } %>
 	<% } %>

--- a/views/partials/highcharts/_wondertrades-byDate-chart.ejs
+++ b/views/partials/highcharts/_wondertrades-byDate-chart.ejs
@@ -23,5 +23,5 @@ $('#date-trend-chart').highcharts({
                 return '<b>'+ this.series.name +'</b><br/>'+ this.y;
         }
     },
-    series: [<%- wondertradeTends %>]
+    series: [<%- wondertradeTrends %>]
 });

--- a/views/partials/highcharts/_wondertrades-quickstats-byDate-chart.ejs
+++ b/views/partials/highcharts/_wondertrades-quickstats-byDate-chart.ejs
@@ -21,6 +21,13 @@ $('#date-trend-chart').highcharts({
         },
         min: 0
     },
+    plotOptions: {
+        series: {
+            marker: {
+                enabled: false
+            }
+        }
+    },
     tooltip: {
         formatter: function() {
                 return '<b>'+ this.series.options.shortName +'</b><br/>'+ this.y+'%';


### PR DESCRIPTION
Moving closer to async, but things are broken

Getting the cache functions working again

Refactored more pages

Finished asyncing everything but genderPage

callback gender data

Caching Gender Data

Region pages are async'd

Removed PokemonTable (it added a redundant traversal)

async-iffy random sample

Convention dictates that I should expect an error object first

Async code cleanup (using waterfall where appropriate)

Removing getSortedCountsByPokemonId (redundant)

Continuing the crusade against _., also added a 500 page :)

Updating getDataCountsSplitByTime()

More _. removal

_. is officially gone

Fixing broken bits

Change dates page to only show past 6 months

Loading a page should never have to incur an expensive parsing operation, thats for the cache to handle